### PR TITLE
Allows for "0" and 0 in tag parameter

### DIFF
--- a/check_test.go
+++ b/check_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Check", func() {
 		BeforeEach(func() {
 			req.Source = resource.Source{
 				Repository: "concourse/test-image-static",
-				RawTag:     "latest",
+				Tag:        "latest",
 			}
 
 			req.Version = nil
@@ -59,7 +59,7 @@ var _ = Describe("Check", func() {
 		BeforeEach(func() {
 			req.Source = resource.Source{
 				Repository: "concourse/test-image-static",
-				RawTag:     "latest",
+				Tag:        "latest",
 			}
 
 			req.Version = &resource.Version{
@@ -78,7 +78,7 @@ var _ = Describe("Check", func() {
 		BeforeEach(func() {
 			req.Source = resource.Source{
 				Repository: "concourse/test-image-static",
-				RawTag:     "latest",
+				Tag:        "latest",
 			}
 
 			req.Version = &resource.Version{
@@ -99,7 +99,7 @@ var _ = Describe("Check", func() {
 		BeforeEach(func() {
 			req.Source = resource.Source{
 				Repository: "concourse/test-image-static",
-				RawTag:     "latest",
+				Tag:        "latest",
 			}
 
 			req.Version = &resource.Version{

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -33,9 +33,7 @@ func main() {
 		return
 	}
 
-	ref := req.Source.Repository + ":" + req.Source.Tag()
-
-	n, err := name.ParseReference(ref, name.WeakValidation)
+	n, err := name.ParseReference(req.Source.Name(), name.WeakValidation)
 	if err != nil {
 		logrus.Errorf("could not resolve repository/tag reference: %s", err)
 		os.Exit(1)

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -112,7 +112,7 @@ func saveDigest(dest string, image v1.Image) error {
 }
 
 func ociFormat(dest string, req InRequest, image v1.Image) {
-	tag, err := name.NewTag(req.Source.Repository+":"+req.Source.Tag(), name.WeakValidation)
+	tag, err := name.NewTag(req.Source.Name(), name.WeakValidation)
 	if err != nil {
 		logrus.Errorf("failed to construct tag reference: %s", err)
 		os.Exit(1)

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -58,7 +58,7 @@ func main() {
 
 	logrus.Warnln("'put' is experimental, untested, and subject to change!")
 
-	ref := req.Source.Repository + ":" + req.Source.Tag()
+	ref := req.Source.Name()
 
 	n, err := name.ParseReference(ref, name.WeakValidation)
 	if err != nil {

--- a/types.go
+++ b/types.go
@@ -1,10 +1,15 @@
 package resource
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 const DefaultTag = "latest"
 
 type Source struct {
 	Repository string `json:"repository"`
-	RawTag     string `json:"tag"`
+	Tag        Tag    `json:"tag"`
 
 	Username string `json:"username"`
 	Password string `json:"password"`
@@ -12,12 +17,27 @@ type Source struct {
 	Debug bool `json:"debug"`
 }
 
-func (s Source) Tag() string {
-	if s.RawTag == "" {
-		return DefaultTag
+func (source *Source) Name() string {
+	return fmt.Sprintf("%s:%s", source.Repository, source.Tag)
+}
+
+type Tag string
+
+func (tag *Tag) UnmarshalJSON(b []byte) error {
+	var n json.Number
+
+	err := json.Unmarshal(b, &n)
+	if err != nil {
+		return err
 	}
 
-	return s.RawTag
+	if n.String() == "" {
+		*tag = Tag(DefaultTag)
+		return nil
+	}
+
+	*tag = Tag(n.String())
+	return nil
 }
 
 type Version struct {

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,41 @@
+package resource_test
+
+import (
+	"encoding/json"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	resource "github.com/concourse/registry-image-resource"
+)
+
+var _ = Describe("Source", func() {
+	It("should unmarshal tag int value into a string", func() {
+		var source resource.Source
+		raw := []byte(`{ "tag": 0 }`)
+
+		err := json.Unmarshal(raw, &source)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(source.Tag).To(Equal(resource.Tag("0")))
+	})
+
+	It("should unmarshal tag '' value to latest", func() {
+		var source resource.Source
+		raw := []byte(`{ "tag": "" }`)
+
+		err := json.Unmarshal(raw, &source)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(source.Tag).To(Equal(resource.Tag("latest")))
+	})
+
+	It("should marshal a tag back out to a string", func() {
+		source := resource.Source{
+			Tag: "0",
+		}
+
+		json, err := json.Marshal(source)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(strings.Contains(string(json[:]), `"tag":"0"`)).To(BeTrue())
+	})
+})

--- a/types_test.go
+++ b/types_test.go
@@ -20,6 +20,15 @@ var _ = Describe("Source", func() {
 		Expect(source.Tag).To(Equal(resource.Tag("0")))
 	})
 
+	It("should unmarshal tag string value into a string", func() {
+		var source resource.Source
+		raw := []byte(`{ "tag": "foo" }`)
+
+		err := json.Unmarshal(raw, &source)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(source.Tag).To(Equal(resource.Tag("foo")))
+	})
+
 	It("should unmarshal tag '' value to latest", func() {
 		var source resource.Source
 		raw := []byte(`{ "tag": "" }`)


### PR DESCRIPTION
Was using this resource and was getting...

```
resource script '/opt/resource/check []' failed: exit status 1

stderr:
[31mERRO[0m[0000] invalid payload: json: cannot unmarshal number into Go struct field Source.tag of type string 
```

This change/refactor will allow for the resource to process whether a user inputs "0" or 0 into as a parameter.