### PR TITLE
feat:support private repository

### DIFF
--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -10,6 +10,7 @@ import (
 
 	resource "github.com/concourse/registry-image-resource"
 	color "github.com/fatih/color"
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -74,7 +75,17 @@ func main() {
 
 	fmt.Fprintf(os.Stderr, "fetching %s@%s\n", color.GreenString(req.Source.Repository), color.YellowString(req.Version.Digest))
 
-	image, err := remote.Image(n)
+	auth := &authn.Basic{
+		Username: req.Source.Username,
+		Password: req.Source.Password,
+	}
+	var image v1.Image
+	if auth.Username != "" && auth.Password != "" {
+		image, err = remote.Image(n, remote.WithAuth(auth))
+
+	} else {
+		image, err = remote.Image(n)
+	}
 	if err != nil {
 		logrus.Errorf("failed to locate remote image: %s", err)
 		os.Exit(1)


### PR DESCRIPTION
#1 
not using authentication information in `in` and `check` , we responded to problems that could not be used in private repository :)

check: `ERROR failed get image digest: UNAUTHORIZED: "authentication required" `
in: `ERRO[0004] failed to extract image: UNAUTHORIZED: "authentication required" `