### PR TITLE
adds repo & tag to metadata for in & out cmd

### DIFF
--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -106,20 +106,9 @@ func main() {
 		return
 	}
 
-	meta := []resource.MetadataField{
-		resource.MetadataField{
-			Name:  "repository",
-			Value: req.Source.Repository,
-		},
-		resource.MetadataField{
-			Name:  "tag",
-			Value: string(req.Source.Tag),
-		},
-	}
-
 	json.NewEncoder(os.Stdout).Encode(InResponse{
 		Version:  req.Version,
-		Metadata: meta,
+		Metadata: req.Source.Metadata(),
 	})
 }
 

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -106,9 +106,20 @@ func main() {
 		return
 	}
 
+	meta := []resource.MetadataField{
+		resource.MetadataField{
+			Name:  "repository",
+			Value: req.Source.Repository,
+		},
+		resource.MetadataField{
+			Name:  "tag",
+			Value: string(req.Source.Tag),
+		},
+	}
+
 	json.NewEncoder(os.Stdout).Encode(InResponse{
 		Version:  req.Version,
-		Metadata: []resource.MetadataField{},
+		Metadata: meta,
 	})
 }
 

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -101,6 +101,6 @@ func main() {
 		Version: resource.Version{
 			Digest: digest.String(),
 		},
-		Metadata: []resource.MetadataField{},
+		Metadata: req.Source.Metadata(),
 	})
 }

--- a/in_test.go
+++ b/in_test.go
@@ -92,6 +92,27 @@ var _ = Describe("In", func() {
 		})
 	})
 
+	Describe("response metadata", func() {
+		BeforeEach(func() {
+			req.Source.Repository = "concourse/test-image-metadata"
+			req.Version.Digest = latestDigest(req.Source.Repository)
+		})
+
+		It("returns metadata", func() {
+			Expect(res.Version).To(Equal(req.Version))
+			Expect(res.Metadata).To(Equal([]resource.MetadataField{
+				resource.MetadataField{
+					Name:  "repository",
+					Value: "concourse/test-image-metadata",
+				},
+				resource.MetadataField{
+					Name:  "tag",
+					Value: "latest",
+				},
+			}))
+		})
+	})
+
 	Describe("file attributes", func() {
 		BeforeEach(func() {
 			req.Source.Repository = "concourse/test-image-file-perms-mtime"

--- a/out_test.go
+++ b/out_test.go
@@ -102,5 +102,18 @@ var _ = Describe("Out", func() {
 
 			Expect(pushedDigest).To(Equal(randomDigest))
 		})
+
+		It("returns metadata", func() {
+			Expect(res.Metadata).To(Equal([]resource.MetadataField{
+				resource.MetadataField{
+					Name:  "repository",
+					Value: dockerPushRepo,
+				},
+				resource.MetadataField{
+					Name:  "tag",
+					Value: "latest",
+				},
+			}))
+		})
 	})
 })

--- a/types.go
+++ b/types.go
@@ -21,6 +21,19 @@ func (source *Source) Name() string {
 	return fmt.Sprintf("%s:%s", source.Repository, source.Tag)
 }
 
+func (source *Source) Metadata() []MetadataField {
+	return []MetadataField{
+		MetadataField{
+			Name:  "repository",
+			Value: source.Repository,
+		},
+		MetadataField{
+			Name:  "tag",
+			Value: string(source.Tag),
+		},
+	}
+}
+
 type Tag string
 
 func (tag *Tag) UnmarshalJSON(b []byte) error {


### PR DESCRIPTION
Returning this metadata will help identify targeted repos and tags on the resource details view.