### PR TITLE
Add support for additional_tags put param

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,11 @@ RUN chmod +x /opt/resource/*
 FROM resource AS tests
 COPY --from=builder /tests /tests
 ADD . /docker-image-resource
-ARG DOCKER_USERNAME
-ARG DOCKER_PASSWORD
+ARG DOCKER_PRIVATE_USERNAME
+ARG DOCKER_PRIVATE_PASSWORD
 ARG DOCKER_PRIVATE_REPO
+ARG DOCKER_PUSH_USERNAME
+ARG DOCKER_PUSH_PASSWORD
 ARG DOCKER_PUSH_REPO
 RUN set -e; for test in /tests/*.test; do \
 		$test -ginkgo.v; \

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ In this format, the resource will produce the following files:
 ### `out`: Push an image up to the registry under the given tags.
 
 Uploads an image to the registry under the tag configured in `source`.
+ 
+If `additional_tags` param is defined then the uploaded image will also be 
+tagged with each one of the values specified in that file.
 
 The currently encouraged way to build these images is by using the
 [`concourse/builder` task](https://github.com/concourse/builder).
@@ -95,3 +98,6 @@ The currently encouraged way to build these images is by using the
 #### Parameters
 
 * `image`: *Required.* The path to the OCI image tarball to upload.
+* `additional_tags`: *Optional.* The path to a file with whitespace-separated 
+list of tag values to tag the image with (in addition to the tag configured in 
+`source`).

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -56,13 +57,32 @@ func main() {
 
 	src := os.Args[1]
 
-	ref := req.Source.Name()
-
-	n, err := name.ParseReference(ref, name.WeakValidation)
+	ref, err := name.ParseReference(req.Source.Name(), name.WeakValidation)
 	if err != nil {
 		logrus.Errorf("could not resolve repository/tag reference: %s", err)
 		os.Exit(1)
 		return
+	}
+
+	tags, err := req.Params.ParseTags(src)
+	if err != nil {
+		logrus.Errorf("could not parse additional tags: %s", err)
+		os.Exit(1)
+		return
+	}
+
+	var extraRefs []name.Reference
+	for _, tag := range tags {
+		n := fmt.Sprintf("%s:%s", req.Source.Repository, tag)
+
+		extraRef, err := name.ParseReference(n, name.WeakValidation)
+		if err != nil {
+			logrus.Errorf("could not resolve repository/tag reference: %s", err)
+			os.Exit(1)
+			return
+		}
+
+		extraRefs = append(extraRefs, extraRef)
 	}
 
 	imagePath := filepath.Join(src, req.Params.Image)
@@ -81,14 +101,14 @@ func main() {
 		return
 	}
 
-	logrus.Infof("pushing %s to %s", digest, ref)
+	logrus.Infof("pushing %s to %s", digest, ref.Name())
 
 	auth := &authn.Basic{
 		Username: req.Source.Username,
 		Password: req.Source.Password,
 	}
 
-	err = remote.Write(n, img, auth, http.DefaultTransport)
+	err = remote.Write(ref, img, auth, http.DefaultTransport)
 	if err != nil {
 		logrus.Errorf("failed to upload image: %s", err)
 		os.Exit(1)
@@ -97,10 +117,23 @@ func main() {
 
 	logrus.Info("pushed")
 
+	for _, extraRef := range extraRefs {
+		logrus.Infof("tagging %s with %s", digest, extraRef.Identifier())
+
+		err = remote.Write(extraRef, img, auth, http.DefaultTransport)
+		if err != nil {
+			logrus.Errorf("failed to tag image: %s", err)
+			os.Exit(1)
+			return
+		}
+
+		logrus.Info("tagged")
+	}
+
 	json.NewEncoder(os.Stdout).Encode(OutResponse{
 		Version: resource.Version{
 			Digest: digest.String(),
 		},
-		Metadata: req.Source.Metadata(),
+		Metadata: req.Source.MetadataWithAdditionalTags(tags),
 	})
 }


### PR DESCRIPTION
Hi @vito tried to implement what was discussed in https://github.com/concourse/registry-image-resource/issues/7. I'm a complete n00b with golang so reviewer beware :warning: 

I tried looking in go-containerregistry to see if there was an easier way to just push new manifests, but they [don't seem to support that yet](https://github.com/google/go-containerregistry/issues/349) so I ended up just pushing the image with different tags (the go-containerregistry will still go through all layers but will end up skipping them all because they already exist in the repo).

I did change `tag` property to `tags` in the out metadata however I think that should not break any existing use of the resource (was the only thing that changed the existing API).

I also need a little guidance on how I should go about writing the tests... do you need to setup a private docker registry from them to work? I would assume the best place for testing this would be `out_test.go` ?

I did a very quick test with a pipeline and it worked (first push uploads all layers, subsequent pushes are almost instant and only push the manifest).