### PR TITLE
add support for ECR repositories with ability to assume role

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ differences:
 
 ## Source Configuration
 
-* `repository`: *Required.* The name of the repository, e.g. `alpine`.
+* `repository`: *Required.* The name of the repository, e.g. `alpine`. If using ecr
+    you only need the repository name, not the full URI e.g. `alpine` not
+    `012345678910.dkr.ecr.us-east-1.amazonaws.com/alpine`
 
 * `tag`: *Optional. Default `latest`.* The name of the tag to monitor and
   publish to.
@@ -34,6 +36,21 @@ differences:
 * `username` and `password`: *Optional.* A username and password to use when
   authenticating to the registry. Must be specified for private repos or when
   using `put`.
+
+* `ecr`: *Optional. Default `false`.* If set, Access Key ID and secret will be
+  used to authenticate, `username` and `password` will be ignored.
+
+* `aws_access_key_id`: *Optional. Default `"""`.* If set, will be used to set
+    `AWS_ACCESS_KEY_ID` environment variable
+
+* `aws_secret_access_key`: *Optional. Default `"""`.* If set, will be used to set
+    `AWS_SECRET_ACCESS_KEY` environment variable
+
+* `aws_region`: *Optional. Default `"`.* If set, will be used to set
+    `AWS_REGION` environment variable
+
+* `aws_role_arn`: *Optional. Default `"`.* If set **and** `ecr` set, then
+the role will be assumed before authenticating to ECR
 
 * `debug`: *Optional. Default `false`.* If set, progress bars will be disabled
   and debugging output will be printed instead.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ differences:
 
 * `aws_role_arn`: *Optional. Default `"`.* If set **and** `ecr` set, then
 the role will be assumed before authenticating to ECR
+* `aws_access_key_id`, `aws_secret_access_key` and `aws_region`: *Optional.*
+  Used to authenticate to ECR repos. Must be specified for ECR repos.
+  Setting these will override `username` and `password`
+
+* `aws_role_arn`: *Optional.* If set, then the role will be assumed before
+  authenticating to ECR. **Requires** `aws_access_key_id`, `aws_secret_access_key`
+  to be set.
 
 * `debug`: *Optional. Default `false`.* If set, progress bars will be disabled
   and debugging output will be printed instead.

--- a/README.md
+++ b/README.md
@@ -37,27 +37,16 @@ differences:
   authenticating to the registry. Must be specified for private repos or when
   using `put`.
 
-* `ecr`: *Optional. Default `false`.* If set, Access Key ID and secret will be
-  used to authenticate, `username` and `password` will be ignored.
+* `aws_access_key_id`: *Optional. Default `"""`.* The access key ID to use for
+  authenticating with ECR.
 
-* `aws_access_key_id`: *Optional. Default `"""`.* If set, will be used to set
-    `AWS_ACCESS_KEY_ID` environment variable
+* `aws_secret_access_key`: *Optional. Default `"""`.* The secret access key to
+  use for authenticating with ECR.
 
-* `aws_secret_access_key`: *Optional. Default `"""`.* If set, will be used to set
-    `AWS_SECRET_ACCESS_KEY` environment variable
+* `aws_region`: *Optional. Default `"`.* The region to use for accessing ECR.
 
-* `aws_region`: *Optional. Default `"`.* If set, will be used to set
-    `AWS_REGION` environment variable
-
-* `aws_role_arn`: *Optional. Default `"`.* If set **and** `ecr` set, then
-the role will be assumed before authenticating to ECR
-* `aws_access_key_id`, `aws_secret_access_key` and `aws_region`: *Optional.*
-  Used to authenticate to ECR repos. Must be specified for ECR repos.
-  Setting these will override `username` and `password`
-
-* `aws_role_arn`: *Optional.* If set, then the role will be assumed before
-  authenticating to ECR. **Requires** `aws_access_key_id`, `aws_secret_access_key`
-  to be set.
+* `aws_role_arn`: *Optional. Default `"`.* If set, then this role will be
+  assumed before authenticating to ECR.
 
 * `debug`: *Optional. Default `false`.* If set, progress bars will be disabled
   and debugging output will be printed instead.

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -1,18 +1,11 @@
 package main
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
 	"os"
-	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ecr"
 	resource "github.com/concourse/registry-image-resource"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/logs"
@@ -49,66 +42,11 @@ func main() {
 		return
 	}
 
-	if req.Source.Ecr {
-		if req.Source.AwsAccessKeyId != "" {
-			os.Setenv("AWS_ACCESS_KEY_ID", req.Source.AwsAccessKeyId)
-		}
-		if req.Source.AwsSecretAccessKey != "" {
-			os.Setenv("AWS_SECRET_ACCESS_KEY", req.Source.AwsSecretAccessKey)
-		}
-		if req.Source.AwsRegion != "" {
-			os.Setenv("AWS_REGION", req.Source.AwsRegion)
-		}
-		mySession := session.Must(session.NewSession())
-		client := ecr.New(mySession)
-		// If a role arn has been supplied, then assume role and get a new session
-		if req.Source.AwsRoleArn != "" {
-			creds := stscreds.NewCredentials(mySession, req.Source.AwsRoleArn)
-			client = ecr.New(mySession, &aws.Config{Credentials: creds})
-		}
-		input := &ecr.GetAuthorizationTokenInput{}
-		result, err := client.GetAuthorizationToken(input)
-		if err != nil {
-			if aerr, ok := err.(awserr.Error); ok {
-				switch aerr.Code() {
-				case ecr.ErrCodeServerException:
-					logrus.Errorf(ecr.ErrCodeServerException)
-					logrus.Errorf(aerr.Error())
-				case ecr.ErrCodeInvalidParameterException:
-					logrus.Errorf(ecr.ErrCodeInvalidParameterException)
-					logrus.Errorf(aerr.Error())
-				default:
-					logrus.Errorf(aerr.Error())
-				}
-			} else {
-				// Print the error, cast err to awserr.Error to get the Code and
-				// Message from an error.
-				logrus.Errorf(err.Error())
-			}
+	if req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "" {
+		if !req.Source.AuthenticateToECR() {
+			os.Exit(1)
 			return
 		}
-
-		for _, data := range result.AuthorizationData {
-			output, err := base64.StdEncoding.DecodeString(*data.AuthorizationToken)
-
-			if err != nil {
-				logrus.Errorf("Failed to decode credential (%s)", err.Error())
-				return
-			}
-
-			split := strings.Split(string(output), ":")
-
-			if len(split) == 2 {
-				req.Source.Password = strings.TrimSpace(split[1])
-			} else {
-				logrus.Errorf("Failed to parse password.")
-				return
-			}
-		}
-
-		// Update username and repository
-		req.Source.Username = "AWS"
-		req.Source.Repository = strings.Join([]string{strings.Replace(*result.AuthorizationData[0].ProxyEndpoint, "https://", "", -1), req.Source.Repository}, "/")
 	}
 
 	ref, err := name.ParseReference(req.Source.Name(), name.WeakValidation)

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -1,11 +1,18 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ecr"
 	resource "github.com/concourse/registry-image-resource"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/logs"
@@ -40,6 +47,68 @@ func main() {
 		logrus.Errorf("invalid payload: %s", err)
 		os.Exit(1)
 		return
+	}
+
+	if req.Source.Ecr {
+		if req.Source.AwsAccessKeyId != "" {
+			os.Setenv("AWS_ACCESS_KEY_ID", req.Source.AwsAccessKeyId)
+		}
+		if req.Source.AwsSecretAccessKey != "" {
+			os.Setenv("AWS_SECRET_ACCESS_KEY", req.Source.AwsSecretAccessKey)
+		}
+		if req.Source.AwsRegion != "" {
+			os.Setenv("AWS_REGION", req.Source.AwsRegion)
+		}
+		mySession := session.Must(session.NewSession())
+		client := ecr.New(mySession)
+		// If a role arn has been supplied, then assume role and get a new session
+		if req.Source.AwsRoleArn != "" {
+			creds := stscreds.NewCredentials(mySession, req.Source.AwsRoleArn)
+			client = ecr.New(mySession, &aws.Config{Credentials: creds})
+		}
+		input := &ecr.GetAuthorizationTokenInput{}
+		result, err := client.GetAuthorizationToken(input)
+		if err != nil {
+			if aerr, ok := err.(awserr.Error); ok {
+				switch aerr.Code() {
+				case ecr.ErrCodeServerException:
+					logrus.Errorf(ecr.ErrCodeServerException)
+					logrus.Errorf(aerr.Error())
+				case ecr.ErrCodeInvalidParameterException:
+					logrus.Errorf(ecr.ErrCodeInvalidParameterException)
+					logrus.Errorf(aerr.Error())
+				default:
+					logrus.Errorf(aerr.Error())
+				}
+			} else {
+				// Print the error, cast err to awserr.Error to get the Code and
+				// Message from an error.
+				logrus.Errorf(err.Error())
+			}
+			return
+		}
+
+		for _, data := range result.AuthorizationData {
+			output, err := base64.StdEncoding.DecodeString(*data.AuthorizationToken)
+
+			if err != nil {
+				logrus.Errorf("Failed to decode credential (%s)", err.Error())
+				return
+			}
+
+			split := strings.Split(string(output), ":")
+
+			if len(split) == 2 {
+				req.Source.Password = strings.TrimSpace(split[1])
+			} else {
+				logrus.Errorf("Failed to parse password.")
+				return
+			}
+		}
+
+		// Update username and repository
+		req.Source.Username = "AWS"
+		req.Source.Repository = strings.Join([]string{strings.Replace(*result.AuthorizationData[0].ProxyEndpoint, "https://", "", -1), req.Source.Repository}, "/")
 	}
 
 	ref, err := name.ParseReference(req.Source.Name(), name.WeakValidation)

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -1,13 +1,20 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ecr"
 	resource "github.com/concourse/registry-image-resource"
 	color "github.com/fatih/color"
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -67,6 +74,68 @@ func main() {
 	}
 
 	dest := os.Args[1]
+
+	if req.Source.Ecr {
+		if req.Source.AwsAccessKeyId != "" {
+			os.Setenv("AWS_ACCESS_KEY_ID", req.Source.AwsAccessKeyId)
+		}
+		if req.Source.AwsSecretAccessKey != "" {
+			os.Setenv("AWS_SECRET_ACCESS_KEY", req.Source.AwsSecretAccessKey)
+		}
+		if req.Source.AwsRegion != "" {
+			os.Setenv("AWS_REGION", req.Source.AwsRegion)
+		}
+		mySession := session.Must(session.NewSession())
+		client := ecr.New(mySession)
+		// If a role arn has been supplied, then assume role and get a new session
+		if req.Source.AwsRoleArn != "" {
+			creds := stscreds.NewCredentials(mySession, req.Source.AwsRoleArn)
+			client = ecr.New(mySession, &aws.Config{Credentials: creds})
+		}
+		input := &ecr.GetAuthorizationTokenInput{}
+		result, err := client.GetAuthorizationToken(input)
+		if err != nil {
+			if aerr, ok := err.(awserr.Error); ok {
+				switch aerr.Code() {
+				case ecr.ErrCodeServerException:
+					logrus.Errorf(ecr.ErrCodeServerException)
+					logrus.Errorf(aerr.Error())
+				case ecr.ErrCodeInvalidParameterException:
+					logrus.Errorf(ecr.ErrCodeServerException)
+					logrus.Errorf(aerr.Error())
+				default:
+					logrus.Errorf(aerr.Error())
+				}
+			} else {
+				// Print the error, cast err to awserr.Error to get the Code and
+				// Message from an error.
+				logrus.Errorf(err.Error())
+			}
+			return
+		}
+
+		for _, data := range result.AuthorizationData {
+			output, err := base64.StdEncoding.DecodeString(*data.AuthorizationToken)
+
+			if err != nil {
+				logrus.Errorf("Failed to decode credential (%s)", err.Error())
+				return
+			}
+
+			split := strings.Split(string(output), ":")
+
+			if len(split) == 2 {
+				req.Source.Password = strings.TrimSpace(split[1])
+			} else {
+				logrus.Errorf("Failed to parse password.")
+				return
+			}
+		}
+
+		// Update username and repository
+		req.Source.Username = "AWS"
+		req.Source.Repository = strings.Join([]string{strings.Replace(*result.AuthorizationData[0].ProxyEndpoint, "https://", "", -1), req.Source.Repository}, "/")
+	}
 
 	ref, err := name.ParseReference(req.Source.Repository+"@"+req.Version.Digest, name.WeakValidation)
 	if err != nil {

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -1,20 +1,13 @@
 package main
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ecr"
 	resource "github.com/concourse/registry-image-resource"
 	color "github.com/fatih/color"
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -75,66 +68,11 @@ func main() {
 
 	dest := os.Args[1]
 
-	if req.Source.Ecr {
-		if req.Source.AwsAccessKeyId != "" {
-			os.Setenv("AWS_ACCESS_KEY_ID", req.Source.AwsAccessKeyId)
-		}
-		if req.Source.AwsSecretAccessKey != "" {
-			os.Setenv("AWS_SECRET_ACCESS_KEY", req.Source.AwsSecretAccessKey)
-		}
-		if req.Source.AwsRegion != "" {
-			os.Setenv("AWS_REGION", req.Source.AwsRegion)
-		}
-		mySession := session.Must(session.NewSession())
-		client := ecr.New(mySession)
-		// If a role arn has been supplied, then assume role and get a new session
-		if req.Source.AwsRoleArn != "" {
-			creds := stscreds.NewCredentials(mySession, req.Source.AwsRoleArn)
-			client = ecr.New(mySession, &aws.Config{Credentials: creds})
-		}
-		input := &ecr.GetAuthorizationTokenInput{}
-		result, err := client.GetAuthorizationToken(input)
-		if err != nil {
-			if aerr, ok := err.(awserr.Error); ok {
-				switch aerr.Code() {
-				case ecr.ErrCodeServerException:
-					logrus.Errorf(ecr.ErrCodeServerException)
-					logrus.Errorf(aerr.Error())
-				case ecr.ErrCodeInvalidParameterException:
-					logrus.Errorf(ecr.ErrCodeServerException)
-					logrus.Errorf(aerr.Error())
-				default:
-					logrus.Errorf(aerr.Error())
-				}
-			} else {
-				// Print the error, cast err to awserr.Error to get the Code and
-				// Message from an error.
-				logrus.Errorf(err.Error())
-			}
+	if req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "" {
+		if !req.Source.AuthenticateToECR() {
+			os.Exit(1)
 			return
 		}
-
-		for _, data := range result.AuthorizationData {
-			output, err := base64.StdEncoding.DecodeString(*data.AuthorizationToken)
-
-			if err != nil {
-				logrus.Errorf("Failed to decode credential (%s)", err.Error())
-				return
-			}
-
-			split := strings.Split(string(output), ":")
-
-			if len(split) == 2 {
-				req.Source.Password = strings.TrimSpace(split[1])
-			} else {
-				logrus.Errorf("Failed to parse password.")
-				return
-			}
-		}
-
-		// Update username and repository
-		req.Source.Username = "AWS"
-		req.Source.Repository = strings.Join([]string{strings.Replace(*result.AuthorizationData[0].ProxyEndpoint, "https://", "", -1), req.Source.Repository}, "/")
 	}
 
 	ref, err := name.ParseReference(req.Source.Repository+"@"+req.Version.Digest, name.WeakValidation)

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -10,13 +9,6 @@ import (
 	"path/filepath"
 
 	resource "github.com/concourse/registry-image-resource"
-	"strings"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/fatih/color"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/logs"
@@ -71,66 +63,11 @@ func main() {
 
 	src := os.Args[1]
 
-	if req.Source.Ecr {
-		if req.Source.AwsAccessKeyId != "" {
-			os.Setenv("AWS_ACCESS_KEY_ID", req.Source.AwsAccessKeyId)
-		}
-		if req.Source.AwsSecretAccessKey != "" {
-			os.Setenv("AWS_SECRET_ACCESS_KEY", req.Source.AwsSecretAccessKey)
-		}
-		if req.Source.AwsRegion != "" {
-			os.Setenv("AWS_REGION", req.Source.AwsRegion)
-		}
-		mySession := session.Must(session.NewSession())
-		client := ecr.New(mySession)
-		// If a role arn has been supplied, then assume role and get a new session
-		if req.Source.AwsRoleArn != "" {
-			creds := stscreds.NewCredentials(mySession, req.Source.AwsRoleArn)
-			client = ecr.New(mySession, &aws.Config{Credentials: creds})
-		}
-		input := &ecr.GetAuthorizationTokenInput{}
-		result, err := client.GetAuthorizationToken(input)
-		if err != nil {
-			if aerr, ok := err.(awserr.Error); ok {
-				switch aerr.Code() {
-				case ecr.ErrCodeServerException:
-					logrus.Errorf(ecr.ErrCodeServerException)
-					logrus.Errorf(aerr.Error())
-				case ecr.ErrCodeInvalidParameterException:
-					logrus.Errorf(ecr.ErrCodeServerException)
-					logrus.Errorf(aerr.Error())
-				default:
-					logrus.Errorf(aerr.Error())
-				}
-			} else {
-				// Print the error, cast err to awserr.Error to get the Code and
-				// Message from an error.
-				logrus.Errorf(err.Error())
-			}
+	if req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "" {
+		if !req.Source.AuthenticateToECR() {
+			os.Exit(1)
 			return
 		}
-
-		for _, data := range result.AuthorizationData {
-			output, err := base64.StdEncoding.DecodeString(*data.AuthorizationToken)
-
-			if err != nil {
-				logrus.Errorf("Failed to decode credential (%s)", err.Error())
-				return
-			}
-
-			split := strings.Split(string(output), ":")
-
-			if len(split) == 2 {
-				req.Source.Password = strings.TrimSpace(split[1])
-			} else {
-				logrus.Errorf("Failed to parse password.")
-				return
-			}
-		}
-
-		// Update username and repository
-		req.Source.Username = "AWS"
-		req.Source.Repository = strings.Join([]string{strings.Replace(*result.AuthorizationData[0].ProxyEndpoint, "https://", "", -1), req.Source.Repository}, "/")
 	}
 
 	ref, err := name.ParseReference(req.Source.Name(), name.WeakValidation)

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -9,6 +10,13 @@ import (
 	"path/filepath"
 
 	resource "github.com/concourse/registry-image-resource"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/fatih/color"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/logs"
@@ -62,6 +70,68 @@ func main() {
 	}
 
 	src := os.Args[1]
+
+	if req.Source.Ecr {
+		if req.Source.AwsAccessKeyId != "" {
+			os.Setenv("AWS_ACCESS_KEY_ID", req.Source.AwsAccessKeyId)
+		}
+		if req.Source.AwsSecretAccessKey != "" {
+			os.Setenv("AWS_SECRET_ACCESS_KEY", req.Source.AwsSecretAccessKey)
+		}
+		if req.Source.AwsRegion != "" {
+			os.Setenv("AWS_REGION", req.Source.AwsRegion)
+		}
+		mySession := session.Must(session.NewSession())
+		client := ecr.New(mySession)
+		// If a role arn has been supplied, then assume role and get a new session
+		if req.Source.AwsRoleArn != "" {
+			creds := stscreds.NewCredentials(mySession, req.Source.AwsRoleArn)
+			client = ecr.New(mySession, &aws.Config{Credentials: creds})
+		}
+		input := &ecr.GetAuthorizationTokenInput{}
+		result, err := client.GetAuthorizationToken(input)
+		if err != nil {
+			if aerr, ok := err.(awserr.Error); ok {
+				switch aerr.Code() {
+				case ecr.ErrCodeServerException:
+					logrus.Errorf(ecr.ErrCodeServerException)
+					logrus.Errorf(aerr.Error())
+				case ecr.ErrCodeInvalidParameterException:
+					logrus.Errorf(ecr.ErrCodeServerException)
+					logrus.Errorf(aerr.Error())
+				default:
+					logrus.Errorf(aerr.Error())
+				}
+			} else {
+				// Print the error, cast err to awserr.Error to get the Code and
+				// Message from an error.
+				logrus.Errorf(err.Error())
+			}
+			return
+		}
+
+		for _, data := range result.AuthorizationData {
+			output, err := base64.StdEncoding.DecodeString(*data.AuthorizationToken)
+
+			if err != nil {
+				logrus.Errorf("Failed to decode credential (%s)", err.Error())
+				return
+			}
+
+			split := strings.Split(string(output), ":")
+
+			if len(split) == 2 {
+				req.Source.Password = strings.TrimSpace(split[1])
+			} else {
+				logrus.Errorf("Failed to parse password.")
+				return
+			}
+		}
+
+		// Update username and repository
+		req.Source.Username = "AWS"
+		req.Source.Repository = strings.Join([]string{strings.Replace(*result.AuthorizationData[0].ProxyEndpoint, "https://", "", -1), req.Source.Repository}, "/")
+	}
 
 	ref, err := name.ParseReference(req.Source.Name(), name.WeakValidation)
 	if err != nil {

--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -11,6 +11,7 @@ RUN set -e; for pkg in $(go list ./...); do \
 	done
 
 FROM ubuntu:bionic AS resource
+DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
       && apt-get install -y --no-install-recommends \
         tzdata \

--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -11,7 +11,7 @@ RUN set -e; for pkg in $(go list ./...); do \
 	done
 
 FROM ubuntu:bionic AS resource
-DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
       && apt-get install -y --no-install-recommends \
         tzdata \

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/concourse/registry-image-resource
 
 require (
 	github.com/VividCortex/ewma v1.1.1 // indirect
+	github.com/aws/aws-sdk-go v1.19.1
 	github.com/cenkalti/backoff v2.1.1+incompatible
 	github.com/concourse/go-archive v1.0.1
 	github.com/fatih/color v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/aws/aws-sdk-go v1.15.90/go.mod h1:es1KtYUFs7le0xQ3rOihkuoVD90z7D0fR2Qm4S00/gU=
+github.com/aws/aws-sdk-go v1.19.1 h1:8kOP0/XGJwXIFlYoD1DAtA39cAjc15Iv/QiDMKitD9U=
+github.com/aws/aws-sdk-go v1.19.1/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -152,6 +154,8 @@ github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkr
 github.com/jinzhu/now v1.0.1 h1:HjfetcXq097iXP0uoPCdnM4Efp5/9MsM0/M+XOTeR3M=
 github.com/jinzhu/now v1.0.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/types.go
+++ b/types.go
@@ -20,6 +20,12 @@ type Source struct {
 	Password     string        `json:"password,omitempty"`
 	ContentTrust *ContentTrust `json:"content_trust,omitempty"`
 
+	Ecr                bool   `json:"ecr,omitempty"`
+	AwsAccessKeyId     string `json:"aws_access_key_id,omitempty"`
+	AwsSecretAccessKey string `json:"aws_secret_access_key,omitempty"`
+	AwsRegion          string `json:"aws_region,omitempty"`
+	AwsRoleArn         string `json:"aws_role_arn,omitempty"`
+
 	Debug bool `json:"debug,omitempty"`
 }
 

--- a/types.go
+++ b/types.go
@@ -156,12 +156,16 @@ func (source *Source) AuthenticateToECR() bool {
 		Region:      aws.String(source.AwsRegion),
 		Credentials: credentials.NewStaticCredentials(source.AwsAccessKeyId, source.AwsSecretAccessKey, ""),
 	}))
-	client := ecr.New(mySession)
+
+	var config aws.Config
+
 	// If a role arn has been supplied, then assume role and get a new session
 	if source.AwsRoleArn != "" {
-		creds := stscreds.NewCredentials(mySession, source.AwsRoleArn)
-		client = ecr.New(mySession, &aws.Config{Credentials: creds})
+		config = aws.Config{Credentials: stscreds.NewCredentials(mySession, source.AwsRoleArn)}
 	}
+
+	client := ecr.New(mySession, &config)
+
 	input := &ecr.GetAuthorizationTokenInput{}
 	result, err := client.GetAuthorizationToken(input)
 	if err != nil {

--- a/types.go
+++ b/types.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -8,6 +9,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/sirupsen/logrus"
 )
 
 const DefaultTag = "latest"
@@ -20,7 +27,6 @@ type Source struct {
 	Password     string        `json:"password,omitempty"`
 	ContentTrust *ContentTrust `json:"content_trust,omitempty"`
 
-	Ecr                bool   `json:"ecr,omitempty"`
 	AwsAccessKeyId     string `json:"aws_access_key_id,omitempty"`
 	AwsSecretAccessKey string `json:"aws_secret_access_key,omitempty"`
 	AwsRegion          string `json:"aws_region,omitempty"`
@@ -141,6 +147,49 @@ func (source *Source) MetadataWithAdditionalTags(tags []string) []MetadataField 
 			Value: strings.Join(append(tags, source.Tag()), " "),
 		},
 	}
+}
+
+func (source *Source) AuthenticateToECR() bool {
+	os.Setenv("AWS_ACCESS_KEY_ID", source.AwsAccessKeyId)
+	os.Setenv("AWS_SECRET_ACCESS_KEY", source.AwsSecretAccessKey)
+	os.Setenv("AWS_REGION", source.AwsRegion)
+	mySession := session.Must(session.NewSession())
+	client := ecr.New(mySession)
+	// If a role arn has been supplied, then assume role and get a new session
+	if source.AwsRoleArn != "" {
+		creds := stscreds.NewCredentials(mySession, source.AwsRoleArn)
+		client = ecr.New(mySession, &aws.Config{Credentials: creds})
+	}
+	input := &ecr.GetAuthorizationTokenInput{}
+	result, err := client.GetAuthorizationToken(input)
+	if err != nil {
+		logrus.Errorf("Failed to authenticate to ECR: %s", err)
+		return false
+	}
+
+	for _, data := range result.AuthorizationData {
+		output, err := base64.StdEncoding.DecodeString(*data.AuthorizationToken)
+
+		if err != nil {
+			logrus.Errorf("Failed to decode credential (%s)", err.Error())
+			return false
+		}
+
+		split := strings.Split(string(output), ":")
+
+		if len(split) == 2 {
+			source.Password = strings.TrimSpace(split[1])
+		} else {
+			logrus.Errorf("Failed to parse password.")
+			return false
+		}
+	}
+
+	// Update username and repository
+	source.Username = "AWS"
+	source.Repository = strings.Join([]string{strings.TrimPrefix(*result.AuthorizationData[0].ProxyEndpoint, "https://"), source.Repository}, "/")
+
+	return true
 }
 
 // Tag refers to a tag for an image in the registry.


### PR DESCRIPTION
Added ability to use ECR. Below are two resources, one checking Docker Hub (public, no auth) and one checking and ECR registry. This fork is currently being built (alpine only) here: https://hub.docker.com/r/dwpdigital/registry-image-resource We are using that image on our Concourse workers.

```
- name: dockerhub_myrepo
  type: registry-image-resource
  source:
    repository: myorg/myrepo
  check_every: 1h
- name: ecr_myrepo
  type: registry-image-resource
  source:
    ecr: true
    repository: 'myrepo'
    aws_role_arn: 'arn:aws:iam::012345678910:role/myrole'
    aws_access_key_id: ((aws_access_key_id))
    aws_secret_access_key: ((aws_secret_access_key))
    aws_region: 'us-east-1'
  check_every: 1h
```