### PR TITLE
Make sure check won't fail if image tag not exist on registry server.

### DIFF
--- a/check_test.go
+++ b/check_test.go
@@ -210,4 +210,36 @@ var _ = Describe("Check", func() {
 			})
 		})
 	})
+
+	Context("when invoked with not exist image", func() {
+		BeforeEach(func() {
+			req.Source = resource.Source{
+				Repository: "concourse/test-image-static",
+				RawTag:     "not-exist-image",
+			}
+			req.Version = nil
+		})
+
+		It("returns empty digest", func() {
+			Expect(res).To(Equal([]resource.Version{}))
+		})
+
+		Context("against a private repo with credentials", func() {
+			BeforeEach(func() {
+				req.Source = resource.Source{
+					Repository: dockerPrivateRepo,
+					RawTag:     "not-exist-image",
+
+					Username: dockerPrivateUsername,
+					Password: dockerPrivatePassword,
+				}
+
+				checkDockerPrivateUserConfigured()
+			})
+
+			It("returns empty digest", func() {
+				Expect(res).To(Equal([]resource.Version{}))
+			})
+		})
+	})
 })


### PR DESCRIPTION
For fix #32, the PR make sure `check` step won't fail if the image tag does not exist on the registry server. 