### PR TITLE
Minor optimization: skip pushing additional tag if the same as source tag

### DIFF
--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -73,6 +73,11 @@ func main() {
 
 	var extraRefs []name.Reference
 	for _, tag := range tags {
+		if tag == req.Source.Tag() {
+			logrus.Debugf("ignoring additional tag %q (same as source tag)", tag)
+			continue
+		}
+
 		n := fmt.Sprintf("%s:%s", req.Source.Repository, tag)
 
 		extraRef, err := name.ParseReference(n, name.WeakValidation)

--- a/dockerfiles/alpine/Dockerfile
+++ b/dockerfiles/alpine/Dockerfile
@@ -12,7 +12,7 @@ RUN set -e; for pkg in $(go list ./...); do \
 
 FROM alpine:edge AS resource
 RUN apk add --no-cache bash tzdata ca-certificates unzip zip gzip tar
-COPY --from=builder assets/ /opt/resource/
+COPY --from=builder /assets/ /opt/resource/
 RUN chmod +x /opt/resource/*
 
 FROM resource AS tests

--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update \
         unzip \
         zip \
       && rm -rf /var/lib/apt/lists/*
-COPY --from=builder assets/ /opt/resource/
+COPY --from=builder /assets/ /opt/resource/
 RUN chmod +x /opt/resource/*
 
 FROM resource AS tests

--- a/out_test.go
+++ b/out_test.go
@@ -135,7 +135,7 @@ var _ = Describe("Out", func() {
 
 				err := ioutil.WriteFile(
 					filepath.Join(srcDir, req.Params.AdditionalTags),
-					[]byte("additional\ntags\n"),
+					[]byte("additional\nlatest\ntags"),
 					0644,
 				)
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Ignore additional tag value if it happens to be the same as the source tag (to avoid unnecessary push).

I also had to "fix" the Dockerfiles, since it it was looking for the assets in `src/assets` when you use buildkit (not sure why but it works fine if docker is used so not sure if it's a bug of docker/buildkit - but with the absolute path it works with both).

On a more curious note, using docker `19.03.1` with buildkit enabled the integration tests aren't run (not really sure why). After I disabled buildkit and ran the exact same docker command the tests were run.

I did a small change to the IT to ensure the skip part doesn't affect the overall functionality but not sure if it is possible to actually check if a push was actually made or not...