### PR TITLE
retry on HTTP 429

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 testdata/.push-output
 .envrc
+tags

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -49,7 +49,7 @@ func main() {
 	}
 
 	imageOpts := []remote.Option{
-		remote.WithTransport(resource.RetryTransport),
+		remote.WithTransport(resource.RetryTransport()),
 	}
 
 	if auth.Username != "" && auth.Password != "" {
@@ -86,13 +86,8 @@ func main() {
 			return
 		}
 
-		var digestImage v1.Image
+		digestImage, err := remote.Image(digestRef, imageOpts...)
 		var missingDigest bool
-		if auth.Username != "" && auth.Password != "" {
-			digestImage, err = remote.Image(digestRef, remote.WithAuth(auth))
-		} else {
-			digestImage, err = remote.Image(digestRef)
-		}
 		if err != nil {
 			missingDigest = checkMissingManifest(err)
 			if !missingDigest {

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -80,7 +80,7 @@ func main() {
 	}
 
 	imageOpts := []remote.Option{
-		remote.WithTransport(resource.RetryTransport),
+		remote.WithTransport(resource.RetryTransport()),
 	}
 
 	if auth.Username != "" && auth.Password != "" {

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -125,7 +125,7 @@ func main() {
 		Password: req.Source.Password,
 	}
 
-	err = remote.Write(ref, img, remote.WithAuth(auth), remote.WithTransport(resource.RetryTransport))
+	err = remote.Write(ref, img, remote.WithAuth(auth), remote.WithTransport(resource.RetryTransport()))
 	if err != nil {
 		logrus.Errorf("failed to upload image: %s", err)
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,11 @@
 module github.com/concourse/registry-image-resource
 
 require (
-	code.cloudfoundry.org/lager v2.0.0+incompatible
 	github.com/VividCortex/ewma v1.1.1 // indirect
 	github.com/concourse/go-archive v1.0.1
-	github.com/concourse/retryhttp v0.0.0-20181126170240-7ab5e29e634f
 	github.com/fatih/color v1.7.0
 	github.com/google/go-containerregistry v0.0.0-20191018211754-b77a90c667af
+	github.com/hashicorp/go-retryablehttp v0.6.2
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.4 // indirect
 	github.com/onsi/ginkgo v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.37.4 h1:glPeL3BQJsbF6aIIYfZizMwc5LTYz250bDMjttbBGAU=
 cloud.google.com/go v0.37.4/go.mod h1:NHPJ89PdicEuT9hdPXMROBD91xc5uRDxsMtSB16k7hw=
-code.cloudfoundry.org/lager v2.0.0+incompatible h1:WZwDKDB2PLd/oL+USK4b4aEjUymIej9My2nUQ9oWEwQ=
-code.cloudfoundry.org/lager v2.0.0+incompatible/go.mod h1:O2sS7gKP3HM2iemG+EnwvyNQK7pTSC6Foi4QiMp9sSk=
 github.com/Azure/azure-sdk-for-go v19.1.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest v10.15.5+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
@@ -46,8 +44,6 @@ github.com/cloudflare/cfssl v0.0.0-20190627231140-2001f384ec4f h1:WjHSb3zr7akq8U
 github.com/cloudflare/cfssl v0.0.0-20190627231140-2001f384ec4f/go.mod h1:yMWuSON2oQp+43nFtAV/uvKQIFpSPerB57DCt9t8sSA=
 github.com/concourse/go-archive v1.0.1 h1:6jQk0VDiE4G6lNJQ0mLZ7XmxbqI3spO4x0wgVwk4pfo=
 github.com/concourse/go-archive v1.0.1/go.mod h1:Xfo080IPQBmVz3I5ehjCddW3phA2mwv0NFwlpjf5CO8=
-github.com/concourse/retryhttp v0.0.0-20181126170240-7ab5e29e634f h1:YlKSrd1N2/WnG3ce28g6DOj6oXpZbBjH/3G97qdTZns=
-github.com/concourse/retryhttp v0.0.0-20181126170240-7ab5e29e634f/go.mod h1:4+V9YCkKuoV7rg+/No+ZM9FsO3BK4tIJNUiYMI7nki0=
 github.com/containerd/containerd v1.3.0/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -143,6 +139,12 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed h1:5upAirOpQc1Q53c0bnx2ufif5kANL7bfZWcc6VJWJd8=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
+github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
+github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-retryablehttp v0.6.2 h1:bHM2aVXwBtBJWxHtkSrWuI4umABCUczs52eiUS9nSiw=
+github.com/hashicorp/go-retryablehttp v0.6.2/go.mod h1:gEx6HMUGxYYhJScX7W1Il64m6cc2C1mDaW3NQ9sY1FY=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=


### PR DESCRIPTION
Fixes concourse/registry-image-resource#68

Using hashicorp/go-retryablehttp instead of concourse/retryhttp was super easy! However, they have slightly different defaults: before we were using an exponential backoff starting at 1s intervals maxing at 16s intervals and setting max elapsed time of 10m. In our basic testing we just used hashicorp's defaults: 1s initial interval, 30s max interval and max 4 retries. On paper this sounds less tolerant than what we had, but tests still seem to be passing.

We wrote our own RoundTripper implementation because hashicorp has not yet done so themselves: hashicorp/go-retryablehttp#37