### PR TITLE
Add logging for go-containerregistry lib

### DIFF
--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"encoding/json"
-	"github.com/google/go-containerregistry/pkg/logs"
 	"log"
 	"os"
 
 	resource "github.com/concourse/registry-image-resource"
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"github.com/google/go-containerregistry/pkg/logs"
+	"log"
 	"os"
 
 	resource "github.com/concourse/registry-image-resource"
@@ -25,6 +27,8 @@ func main() {
 	logrus.SetFormatter(&logrus.TextFormatter{
 		ForceColors: true,
 	})
+
+	logs.Progress = log.New(os.Stderr, "go-cr-progress-", log.LstdFlags)
 
 	var req CheckRequest
 	decoder := json.NewDecoder(os.Stdin)

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -28,7 +28,8 @@ func main() {
 		ForceColors: true,
 	})
 
-	logs.Progress = log.New(os.Stderr, "go-cr-progress-", log.LstdFlags)
+	logs.Progress = log.New(os.Stderr, "", log.LstdFlags)
+	logs.Warn = log.New(os.Stderr, "", log.LstdFlags)
 
 	var req CheckRequest
 	decoder := json.NewDecoder(os.Stdin)

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -41,8 +41,8 @@ func main() {
 		ForceColors: true,
 	})
 
-	logs.Progress = log.New(os.Stderr, "go-cr-progress-", log.LstdFlags)
-	logs.Warn = log.New(os.Stderr, "go-cr-warn-", log.LstdFlags)
+	logs.Progress = log.New(os.Stderr, "", log.LstdFlags)
+	logs.Warn = log.New(os.Stderr, "", log.LstdFlags)
 
 	color.NoColor = false
 

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/google/go-containerregistry/pkg/logs"
 	"io/ioutil"
 	"log"
 	"os"
@@ -12,6 +11,7 @@ import (
 	resource "github.com/concourse/registry-image-resource"
 	color "github.com/fatih/color"
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/google/go-containerregistry/pkg/logs"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -38,6 +40,9 @@ func main() {
 	logrus.SetFormatter(&logrus.TextFormatter{
 		ForceColors: true,
 	})
+
+	logs.Progress = log.New(os.Stderr, "go-cr-progress-", log.LstdFlags)
+	logs.Warn = log.New(os.Stderr, "go-cr-warn-", log.LstdFlags)
 
 	color.NoColor = false
 

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -3,12 +3,14 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
 
 	"github.com/fatih/color"
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
@@ -33,6 +35,9 @@ func main() {
 	logrus.SetFormatter(&logrus.TextFormatter{
 		ForceColors: true,
 	})
+
+	logs.Progress = log.New(os.Stderr, "go-cr-progress-", log.LstdFlags)
+	logs.Warn = log.New(os.Stderr, "go-cr-warn-", log.LstdFlags)
 
 	color.NoColor = false
 

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -35,8 +35,8 @@ func main() {
 		ForceColors: true,
 	})
 
-	logs.Progress = log.New(os.Stderr, "go-cr-progress-", log.LstdFlags)
-	logs.Warn = log.New(os.Stderr, "go-cr-warn-", log.LstdFlags)
+	logs.Progress = log.New(os.Stderr, "", log.LstdFlags)
+	logs.Warn = log.New(os.Stderr, "", log.LstdFlags)
 
 	color.NoColor = false
 

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -8,16 +8,15 @@ import (
 	"os"
 	"path/filepath"
 
+	resource "github.com/concourse/registry-image-resource"
 	"github.com/fatih/color"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
-	"github.com/sirupsen/logrus"
-
-	resource "github.com/concourse/registry-image-resource"
 	gcr "github.com/simonshyu/notary-gcr/pkg/gcr"
+	"github.com/sirupsen/logrus"
 )
 
 type OutRequest struct {


### PR DESCRIPTION
Initialize progress & warn logs for go-containerregistry lib
Chose not to include debug logs as they log every http response body including to auth endpoints.