### PR TITLE
Adds support for ECR auth when running concourse on an EC2 instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ differences:
 * `aws_role_arn`: *Optional. Default `"`.* If set, then this role will be
   assumed before authenticating to ECR.
 
+* `aws_use_ec2_role_creds`: *Optional. Default `"`.* If set, then the role of the
+  current EC2 instance will be used to authenticate to ECR. Use this when running
+  concourse on EC2.
+
 * `debug`: *Optional. Default `false`.* If set, progress bars will be disabled
   and debugging output will be printed instead.
 

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -42,7 +42,7 @@ func main() {
 		return
 	}
 
-	if req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "" {
+	if req.Source.ShouldAuthenticateToECR() {
 		if !req.Source.AuthenticateToECR() {
 			os.Exit(1)
 			return

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -68,7 +68,7 @@ func main() {
 
 	dest := os.Args[1]
 
-	if req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "" {
+	if req.Source.ShouldAuthenticateToECR() {
 		if !req.Source.AuthenticateToECR() {
 			os.Exit(1)
 			return

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -63,7 +63,7 @@ func main() {
 
 	src := os.Args[1]
 
-	if req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "" {
+	if req.Source.ShouldAuthenticateToECR() {
 		if !req.Source.AuthenticateToECR() {
 			os.Exit(1)
 			return


### PR DESCRIPTION
I run concourse on an EC2 instance which has an instance role which already allows it ECR permissions.

The existing implementation would have forced me to some static credentials available within concourse and I'd rather not if possible as credentials are already available from the metadata API.

There's a similar PR open on the s3-resource: https://github.com/concourse/s3-resource/pull/115