### PR TITLE
Use ECR without AwsAccessKeyId and AwsSecretAccessKey

### DIFF
--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -42,7 +42,7 @@ func main() {
 		return
 	}
 
-	if req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "" {
+	if req.Source.AwsRegion != "" {
 		if !req.Source.AuthenticateToECR() {
 			os.Exit(1)
 			return

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -68,7 +68,7 @@ func main() {
 
 	dest := os.Args[1]
 
-	if req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "" {
+	if req.Source.AwsRegion != "" {
 		if !req.Source.AuthenticateToECR() {
 			os.Exit(1)
 			return

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -63,7 +63,7 @@ func main() {
 
 	src := os.Args[1]
 
-	if req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "" {
+	if req.Source.AwsRegion != "" {
 		if !req.Source.AuthenticateToECR() {
 			os.Exit(1)
 			return

--- a/types.go
+++ b/types.go
@@ -152,10 +152,19 @@ func (source *Source) MetadataWithAdditionalTags(tags []string) []MetadataField 
 
 func (source *Source) AuthenticateToECR() bool {
 	logrus.Warnln("ECR integration is experimental and untested")
-	mySession := session.Must(session.NewSession(&aws.Config{
-		Region:      aws.String(source.AwsRegion),
-		Credentials: credentials.NewStaticCredentials(source.AwsAccessKeyId, source.AwsSecretAccessKey, ""),
-	}))
+
+	var sessionConfig aws.Config
+	if source.AwsAccessKeyId != "" && source.AwsSecretAccessKey != "" {
+ 		sessionConfig = aws.Config{
+			Region:      aws.String(source.AwsRegion),
+			Credentials: credentials.NewStaticCredentials(source.AwsAccessKeyId, source.AwsSecretAccessKey, ""),
+		}
+	} else {
+		sessionConfig = aws.Config{
+			Region:      aws.String(source.AwsRegion),
+		}
+	}
+	mySession := session.Must(session.NewSession(&sessionConfig))
 
 	var config aws.Config
 


### PR DESCRIPTION
This allows ECR to be used if a role is already assumed. Fixes #94