### PR TITLE
Fix Go 1.14 support

### DIFF
--- a/types.go
+++ b/types.go
@@ -205,11 +205,17 @@ type Tag string
 func (tag *Tag) UnmarshalJSON(b []byte) error {
 	var n json.Number
 	err := json.Unmarshal(b, &n)
+	if err == nil {
+		*tag = Tag(n.String())
+		return nil
+	}
+
+	var s string
+	err = json.Unmarshal(b, &s)
 	if err != nil {
 		return err
 	}
-
-	*tag = Tag(n.String())
+	*tag = Tag(s)
 
 	return nil
 }


### PR DESCRIPTION
As per the 1.14 release notes [here](https://golang.google.cn/doc/go1.14)

> Number no longer accepts invalid numbers, to follow the documented behavior more closely.

This is especially problematic as the golang builder image is only major version pinned, so currently the docker images don't build