### PR TITLE
Fix tag parsing for Go 1.14

### DIFF
--- a/types.go
+++ b/types.go
@@ -202,16 +202,17 @@ func (source *Source) AuthenticateToECR() bool {
 type Tag string
 
 // UnmarshalJSON accepts numeric and string values.
-func (tag *Tag) UnmarshalJSON(b []byte) error {
-	var n json.Number
-	err := json.Unmarshal(b, &n)
-	if err != nil {
-		return err
+func (tag *Tag) UnmarshalJSON(b []byte) (err error) {
+	var s string
+	if err = json.Unmarshal(b, &s); err == nil {
+		*tag = Tag(s)
+	} else {
+		var n json.RawMessage
+		if err = json.Unmarshal(b, &n); err == nil {
+			*tag = Tag(n)
+		}
 	}
-
-	*tag = Tag(n.String())
-
-	return nil
+	return err
 }
 
 type Version struct {


### PR DESCRIPTION
The behaviour of json.Number was changed in Go 1.14 to no longer
accept invalid
numbers (https://golang.org/doc/go1.14#encoding/json). This means that
it can no longer be used to handle both strings and numbers, as we
were doing here.

Instead, first try parsing as a string, and if that doesn't work,
convert from number to string via RawMessage.