### PR TITLE
feat: add STS support to ECR registry functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,18 @@ differences:
   authenticating to the registry. Must be specified for private repos or when
   using `put`.
 
-* `aws_access_key_id`: *Optional. Default `"""`.* The access key ID to use for
+* `aws_access_key_id`: *Optional. Default `""`.* The access key ID to use for
   authenticating with ECR.
 
-* `aws_secret_access_key`: *Optional. Default `"""`.* The secret access key to
+* `aws_secret_access_key`: *Optional. Default `""`.* The secret access key to
   use for authenticating with ECR.
 
-* `aws_region`: *Optional. Default `"`.* The region to use for accessing ECR.
+* `aws_session_token`: *Optional. Default `""`.* The session token to use
+  for authenticating with STS credentials with ECR.
 
-* `aws_role_arn`: *Optional. Default `"`.* If set, then this role will be
+* `aws_region`: *Optional. Default `""`.* The region to use for accessing ECR.
+
+* `aws_role_arn`: *Optional. Default `""`.* If set, then this role will be
   assumed before authenticating to ECR.
 
 * `debug`: *Optional. Default `false`.* If set, progress bars will be disabled

--- a/types.go
+++ b/types.go
@@ -30,6 +30,7 @@ type Source struct {
 
 	AwsAccessKeyId     string `json:"aws_access_key_id,omitempty"`
 	AwsSecretAccessKey string `json:"aws_secret_access_key,omitempty"`
+	AwsSessionToken    string `json:"aws_session_token,omitempty"`
 	AwsRegion          string `json:"aws_region,omitempty"`
 	AwsRoleArn         string `json:"aws_role_arn,omitempty"`
 
@@ -154,7 +155,7 @@ func (source *Source) AuthenticateToECR() bool {
 	logrus.Warnln("ECR integration is experimental and untested")
 	mySession := session.Must(session.NewSession(&aws.Config{
 		Region:      aws.String(source.AwsRegion),
-		Credentials: credentials.NewStaticCredentials(source.AwsAccessKeyId, source.AwsSecretAccessKey, ""),
+		Credentials: credentials.NewStaticCredentials(source.AwsAccessKeyId, source.AwsSecretAccessKey, source.AwsSessionToken),
 	}))
 
 	var config aws.Config


### PR DESCRIPTION
Allow the resource to accept a session token in order to use STS
credentials.

Fixes #160.