### PR TITLE
Add /etc/nsswitch.conf so /etc/hosts is read

### DIFF
--- a/dockerfiles/alpine/Dockerfile
+++ b/dockerfiles/alpine/Dockerfile
@@ -14,6 +14,10 @@ FROM alpine:edge AS resource
 RUN apk add --no-cache bash tzdata ca-certificates unzip zip gzip tar
 COPY --from=builder assets/ /opt/resource/
 RUN chmod +x /opt/resource/*
+# Ensure /etc/hosts is honored
+# https://github.com/golang/go/issues/22846
+# https://github.com/gliderlabs/docker-alpine/issues/367
+RUN echo "hosts: files dns" > /etc/nsswitch.conf
 
 FROM resource AS tests
 COPY --from=builder /tests /tests


### PR DESCRIPTION
Addresses https://github.com/concourse/registry-image-resource/issues/203

~I have not yet had a chance to test this.~

I pushed a build to `tvon/registry-image-resource:branch-alpine-nsswitch` and was able to confirm that `/etc/hosts` is honored with this change in a Concourse cluster.