### PR TITLE
Modify Dockerfiles to allow caching of go mod

### DIFF
--- a/dockerfiles/alpine/Dockerfile
+++ b/dockerfiles/alpine/Dockerfile
@@ -1,8 +1,12 @@
 FROM golang:1 as builder
-COPY . /src
 WORKDIR /src
+
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+COPY . .
 ENV CGO_ENABLED 0
-RUN go get -d ./...
 RUN go build -o /assets/in ./cmd/in
 RUN go build -o /assets/out ./cmd/out
 RUN go build -o /assets/check ./cmd/check

--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -1,8 +1,12 @@
 FROM concourse/golang-builder as builder
-COPY . /src
 WORKDIR /src
+
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+COPY . .
 ENV CGO_ENABLED 0
-RUN go get -d ./...
 RUN go build -o /assets/in ./cmd/in
 RUN go build -o /assets/out ./cmd/out
 RUN go build -o /assets/check ./cmd/check


### PR DESCRIPTION
- updates the ubuntu and alpine dockerfiles to allow the caching of the
go mod as intermediate containers, this allows for faster builds.

