### PR TITLE
Document how to specify the digest when used as anonymous resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,29 @@ The currently encouraged way to build these images is by using the
   list of tag values to tag the image with (in addition to the tag configured
   in `source`).
 
+### Use in tasks
+
+Images used as
+[image resources](https://concourse-ci.org/tasks.html#schema.task.image_resource)
+in tasks are called
+[anonymous resources](https://concourse-ci.org/tasks.html#schema.anonymous_resource).
+Anonymous resources can specify
+[a version](https://concourse-ci.org/tasks.html#schema.anonymous_resource.version),
+which is the image digest. For example:
+
+
+```
+image_resource:
+  type: docker-image
+  source:
+    repository: golang
+  version:
+    digest: 'sha256:5f640aeb8b78e9876546a9d06b928d2ad0c6e51900bcba10ff4e12dc57f6f265'
+```
+
+This is useful when the registry image does not have tags, or when the tags are
+going to be re-used.
+
 ## Development
 
 ### Prerequisites


### PR DESCRIPTION
Implements #45 

What
---

As a user,
when using an anonymous resource in a task,
I want to specify the digest of the image_resource,
so that task runs are reproducible:

```
platform: linux
image_resource:
  type: docker-image
  source:
    repository: golang
    digest: 'sha256:b55ababe05036f7d28086d00f5ea585baf4373a20d81979e0f202ced998443a8'
run:
  path: date
```

This is especially useful when the maintainer of the docker image:

- does not publish tags
- re-uses tags

Why
---

I understand the reasoning in #45, namely that pinning is better. I agree that specifying a digest is bad practice for most resources, as they are supposed to be dynamic (unless pinned).

However I think the registry-image-resource (and docker-image-resource) is a special exception as [anonymous resources](https://concourse-ci.org/tasks.html#schema.anonymous_resource) used in tasks. As anonymous resources are checked when the task runs, a user does not have the opportunity to pin them, or control their versioning other than via tags.