### PR TITLE
bumping aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,29 @@ Tags may be specified in multiple ways:
 
 * `image`: *Required.* The path to the OCI image tarball to upload. Expanded
   with [`filepath.Glob`](https://golang.org/pkg/path/filepath/#Glob).
+
 * `version`: *Optional.* A version number to use as a tag.
+
+* `bump_aliases`: *Optional. Default `false`.* When set to `true` and `version`
+  is specified, automatically bump alias tags for the version.
+
+  For example, when pushing version `1.2.3`, push the same image to the
+  following tags:
+
+  * `1.2`, if 1.2.3 is the latest version of 1.2.x.
+  * `1`, if 1.2.3 is the latest version of 1.x.
+  * `latest`, if 1.2.3 is the latest version overall.
+
+  If `variant` is configured as `foo`, push the same image to the following
+  tags:
+
+  * `1.2-foo`, if 1.2.3 is the latest version of 1.2.x with `foo`.
+  * `1-foo`, if 1.2.3 is the latest version of 1.x with `foo`.
+  * `foo`, if 1.2.3 is the latest version overall for `foo`.
+
+  Determining which tags to bump is done by comparing to the existing tags
+  that exist on the registry.
+
 * `additional_tags`: *Optional.* The path to a file with whitespace-separated
   list of tag values to tag the image with (in addition to the tag configured
   in `source`).

--- a/commands/out.go
+++ b/commands/out.go
@@ -255,6 +255,11 @@ func aliasesToBump(req resource.OutRequest, repo name.Repository, ver *semver.Ve
 	for _, v := range versions {
 		versionStr := v
 		if variant != "" {
+			if !strings.HasSuffix(versionStr, "-"+variant) {
+				// don't compare across variants
+				continue
+			}
+
 			versionStr = strings.TrimSuffix(versionStr, "-"+variant)
 		}
 

--- a/commands/out.go
+++ b/commands/out.go
@@ -127,25 +127,30 @@ func (o *Out) Execute() error {
 			bumpMajor := true
 			bumpMinor := true
 			for _, v := range versions {
-				remoteVer, err := semver.NewVersion(v)
+				versionStr := v
+				if req.Source.Variant != "" {
+					versionStr = strings.TrimSuffix(versionStr, "-"+req.Source.Variant)
+				}
+
+				remoteVer, err := semver.NewVersion(versionStr)
 				if err != nil {
 					continue
 				}
 
-				final, err := remoteVer.SetPrerelease("")
-				if err != nil {
+				// don't compare to prereleases or other variants
+				if remoteVer.Prerelease() != "" {
 					continue
 				}
 
-				if final.GreaterThan(ver) {
+				if remoteVer.GreaterThan(ver) {
 					bumpLatest = false
 				}
 
-				if final.Major() == ver.Major() && final.Minor() > ver.Minor() {
+				if remoteVer.Major() == ver.Major() && remoteVer.Minor() > ver.Minor() {
 					bumpMajor = false
 				}
 
-				if final.Major() == ver.Major() && final.Minor() == ver.Minor() && final.Patch() > ver.Patch() {
+				if remoteVer.Major() == ver.Major() && remoteVer.Minor() == ver.Minor() && remoteVer.Patch() > ver.Patch() {
 					bumpMinor = false
 					bumpMajor = false
 				}

--- a/out_test.go
+++ b/out_test.go
@@ -230,7 +230,7 @@ var _ = Describe("Out", func() {
 				for _, t := range []string{"latest", "additional", "tags"} {
 					tag := parallelTag(t)
 
-					name, err := name.ParseReference(req.Source.Repository+":"+tag)
+					name, err := name.ParseReference(req.Source.Repository + ":" + tag)
 					Expect(err).ToNot(HaveOccurred())
 
 					auth := &authn.Basic{
@@ -471,17 +471,16 @@ var _ = DescribeTable("pushing semver tags",
 			PushedTags: []string{"1.2.3", "1.2", "1"},
 		},
 	),
-	Entry("not bumping major if a newer non-variant minor exists",
-		// rationale: tags are representing versions of a cohesive product, so
-		// its versions should be comparable across variants.
+	Entry("bumping everything even if a newer non-variant minor exists",
+		// rationale: 'lts' variants, which are intentionally older
 		SemverTagPushExample{
 			Tags: []string{"1.3.0"},
 
-			Variant:     "foo",
+			Variant:     "lts",
 			Version:     "1.2.3",
 			BumpAliases: true,
 
-			PushedTags: []string{"1.2.3-foo", "1.2-foo"},
+			PushedTags: []string{"1.2.3-lts", "1.2-lts", "1-lts", "lts"},
 		},
 	),
 	Entry("bumping everything if the only available version is a prerelease",

--- a/out_test.go
+++ b/out_test.go
@@ -427,17 +427,6 @@ var _ = DescribeTable("pushing semver tags",
 			PushedTags: []string{"1.2.3-alpha.1"},
 		},
 	),
-	Entry("bumping variant aliases with no existing tags",
-		SemverTagPushExample{
-			Tags: []string{},
-
-			Variant:     "hello",
-			Version:     "1.2.3",
-			BumpAliases: true,
-
-			PushedTags: []string{"1.2.3-hello", "1.2-hello", "1-hello", "hello"},
-		},
-	),
 	Entry("bumping aliases if only older versions exist",
 		SemverTagPushExample{
 			Tags: []string{"1.2.2"},
@@ -480,6 +469,107 @@ var _ = DescribeTable("pushing semver tags",
 			BumpAliases: true,
 
 			PushedTags: []string{"1.2.3", "1.2", "1"},
+		},
+	),
+	Entry("not bumping major if a newer non-variant minor exists",
+		// rationale: tags are representing versions of a cohesive product, so
+		// its versions should be comparable across variants.
+		SemverTagPushExample{
+			Tags: []string{"1.3.0"},
+
+			Variant:     "foo",
+			Version:     "1.2.3",
+			BumpAliases: true,
+
+			PushedTags: []string{"1.2.3-foo", "1.2-foo"},
+		},
+	),
+	Entry("bumping everything if the only available version is a prerelease",
+		SemverTagPushExample{
+			Tags: []string{"2.0.0-rc.1"},
+
+			Variant:     "",
+			Version:     "1.2.3",
+			BumpAliases: true,
+
+			PushedTags: []string{"1.2.3", "1.2", "1", "latest"},
+		},
+	),
+	Entry("bumping everything if the only available version is a different variant",
+		SemverTagPushExample{
+			Tags: []string{"2.0.0-goodbye"},
+
+			Variant:     "hello",
+			Version:     "1.2.3",
+			BumpAliases: true,
+
+			PushedTags: []string{"1.2.3-hello", "1.2-hello", "1-hello", "hello"},
+		},
+	),
+	Entry("bumping variant aliases with no existing tags",
+		SemverTagPushExample{
+			Tags: []string{},
+
+			Variant:     "hello",
+			Version:     "1.2.3",
+			BumpAliases: true,
+
+			PushedTags: []string{"1.2.3-hello", "1.2-hello", "1-hello", "hello"},
+		},
+	),
+	Entry("bumping minor and major, but not latest, if a newer major version exists with the same variant",
+		SemverTagPushExample{
+			Tags: []string{"2.0.0-hello"},
+
+			Variant:     "hello",
+			Version:     "1.2.3",
+			BumpAliases: true,
+
+			PushedTags: []string{"1.2.3-hello", "1.2-hello", "1-hello"},
+		},
+	),
+	Entry("bumping minor and major, but not latest, if a newer major version exists with the same variant",
+		SemverTagPushExample{
+			Tags: []string{"2.0.0-hello"},
+
+			Variant:     "hello",
+			Version:     "1.2.3",
+			BumpAliases: true,
+
+			PushedTags: []string{"1.2.3-hello", "1.2-hello", "1-hello"},
+		},
+	),
+	Entry("bumping aliases if only older versions exist of the same variant",
+		SemverTagPushExample{
+			Tags: []string{"1.2.2-hello"},
+
+			Variant:     "hello",
+			Version:     "1.2.3",
+			BumpAliases: true,
+
+			PushedTags: []string{"1.2.3-hello", "1.2-hello", "1-hello", "hello"},
+		},
+	),
+	Entry("not bumping anything if a newer patch already exists of the same variant",
+		SemverTagPushExample{
+			Tags: []string{"1.2.4-hello"},
+
+			Variant:     "hello",
+			Version:     "1.2.3",
+			BumpAliases: true,
+
+			PushedTags: []string{"1.2.3-hello"},
+		},
+	),
+	Entry("not bumping major if a newer minor already exists of the same variant",
+		SemverTagPushExample{
+			Tags: []string{"1.3.0-hello"},
+
+			Variant:     "hello",
+			Version:     "1.2.3",
+			BumpAliases: true,
+
+			PushedTags: []string{"1.2.3-hello", "1.2-hello"},
 		},
 	),
 )

--- a/types.go
+++ b/types.go
@@ -349,6 +349,18 @@ type PutParams struct {
 	// appended to this value to form the tag.
 	Version string `json:"version"`
 
+	// Bump additional alias tags after pushing the version's tag.
+	//
+	// Given a version without a prerelease, say 1.2.3:
+	//
+	// * If 1.2.3 is the latest of the 1.2.x series, push to the 1.2 tag.
+	//
+	// * If 1.2.3 is the latest of the 1.x series, push to the 1 tag.
+	//
+	// * If 1.2.3 is the latest overall, bump the variant tag, or 'latest'
+	//   if no variant is configured.
+	BumpAliases bool `json:"bump_aliases"`
+
 	// Path to a file containing line-separated tags to push.
 	AdditionalTags string `json:"additional_tags"`
 }


### PR DESCRIPTION
this feature makes it trivial to bump 'alias' tags such as `latest`, `alpine`, `1`, `1.2` when pushing `1.2.3` or `1.2.3-alpine` - see README changes for details!