### PR TITLE
Add support for implicit namespaces when pulling from mirrors

### DIFF
--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -51,7 +51,7 @@ func main() {
 	}
 
 	if len(os.Args) < 2 {
-		logrus.Errorf("destination path not specified")
+		logrus.Error("destination path not specified")
 		os.Exit(1)
 		return
 	}

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -47,7 +47,7 @@ func main() {
 	}
 
 	if len(os.Args) < 2 {
-		logrus.Errorf("destination path not specified")
+		logrus.Error("destination path not specified")
 		os.Exit(1)
 		return
 	}
@@ -125,7 +125,7 @@ func main() {
 
 			versions, err := remote.List(repo, imageOpts...)
 			if err != nil {
-				logrus.Errorf("failed to list repository tags: %w", err)
+				logrus.Error("failed to list repository tags: %w", err)
 				os.Exit(1)
 				return
 			}
@@ -206,7 +206,7 @@ func main() {
 	}
 
 	if len(tagsToPush) == 0 {
-		logrus.Errorf("no tag specified - need either 'version:' in params or 'tag:' in source")
+		logrus.Error("no tag specified - need either 'version:' in params or 'tag:' in source")
 		os.Exit(1)
 		return
 	}

--- a/suite_test.go
+++ b/suite_test.go
@@ -20,6 +20,8 @@ var bins struct {
 	Check string `json:"check"`
 }
 
+const LIBRARY_DIGEST = "sha256:2131f09e4044327fd101ca1fd4043e6f3ad921ae7ee901e9142e6e36b354a907"
+
 // see testdata/static/Dockerfile
 const OLDER_STATIC_DIGEST = "sha256:7dabedca9d367a71d1cd646bd8d79f14de7b07327e4417ab691f5f13be5647a9"
 const LATEST_STATIC_DIGEST = "sha256:fc484c7e21a5616c600778d7ee720b3adfe1373c896be4f068c3da4a205d4a2e"

--- a/types.go
+++ b/types.go
@@ -212,7 +212,7 @@ func (source *Source) AuthenticateToECR() bool {
 		if len(split) == 2 {
 			source.Password = strings.TrimSpace(split[1])
 		} else {
-			logrus.Errorf("failed to parse password.")
+			logrus.Error("failed to parse password.")
 			return false
 		}
 	}


### PR DESCRIPTION
@vito - So I wasn't right after all, you didn't _**quite**_ cover the scenario.

I added tests to cover some scenarios that are already working (miss on mirror, exists in origin). But added a couple of mocked up registry test cases to validate the URL paths submitted for each.

cc: @evanchaoli