### PR TITLE
Add support for implicit namespaces when pulling from mirrors

### DIFF
--- a/check_test.go
+++ b/check_test.go
@@ -88,41 +88,110 @@ var _ = Describe("Check", func() {
 		})
 
 		Context("against a mirror", func() {
-			Context("which has the image", func() {
-				BeforeEach(func() {
-					req.Source = resource.Source{
-						Repository: "fakeserver.foo:5000/concourse/test-image-static",
-						RawTag:     "latest",
+			var mirror *ghttp.Server
 
-						RegistryMirror: &resource.RegistryMirror{
+			BeforeEach(func() {
+				mirror = ghttp.NewServer()
+			})
+
+			AfterEach(func() {
+				mirror.Close()
+			})
+
+			Context("which has the image", func() {
+				Context("in an explicit namespace", func() {
+					BeforeEach(func() {
+						// use the mock mirror as the "origin", use Docker Hub as a "mirror"
+						req.Source.Repository = mirror.Addr() + "/" + req.Source.Repository
+						req.Source.RegistryMirror = &resource.RegistryMirror{
 							Host: name.DefaultRegistry,
-						},
-					}
+						}
+					})
+
+					It("returns the current digest", func() {
+						Expect(res).To(Equal([]resource.Version{
+							{Digest: LATEST_STATIC_DIGEST},
+						}))
+					})
 				})
 
-				It("returns the current digest", func() {
-					Expect(res).To(Equal([]resource.Version{
-						{Digest: LATEST_STATIC_DIGEST},
-					}))
+				Context("in an implied namespace", func() {
+					BeforeEach(func() {
+						mirror.AppendHandlers(
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/"),
+								ghttp.RespondWith(http.StatusOK, `welcome to zombocom`),
+							),
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/library/fake-image/manifests/latest"),
+								ghttp.RespondWith(http.StatusOK, `{"fake":"manifest"}`),
+							),
+						)
+
+						req.Source.Repository = "fake-image"
+						req.Source.RegistryMirror = &resource.RegistryMirror{
+							Host: mirror.Addr(),
+						}
+					})
+
+					It("returns the current digest", func() {
+						Expect(res).To(Equal([]resource.Version{
+							{Digest: LATEST_FAKE_DIGEST},
+						}))
+					})
 				})
 			})
 
 			Context("which is missing the image", func() {
 				BeforeEach(func() {
-					req.Source = resource.Source{
-						Repository: "concourse/test-image-static",
-						RawTag:     "latest",
-
-						RegistryMirror: &resource.RegistryMirror{
-							Host: "fakeserver.foo:5000",
-						},
+					req.Source.RegistryMirror = &resource.RegistryMirror{
+						Host: mirror.Addr(),
 					}
 				})
 
-				It("returns the current digest", func() {
-					Expect(res).To(Equal([]resource.Version{
-						{Digest: LATEST_STATIC_DIGEST},
-					}))
+				Context("in an explicit namespace", func() {
+					BeforeEach(func() {
+						mirror.AppendHandlers(
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/"),
+								ghttp.RespondWith(http.StatusOK, `welcome to zombocom`),
+							),
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/concourse/test-image-static/manifests/latest"),
+								ghttp.RespondWith(http.StatusNotFound, nil),
+							),
+						)
+					})
+
+					It("returns the current digest", func() {
+						Expect(res).To(Equal([]resource.Version{
+							{Digest: LATEST_STATIC_DIGEST},
+						}))
+					})
+				})
+
+				Context("in an implied namespace", func() {
+					BeforeEach(func() {
+						mirror.AppendHandlers(
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/"),
+								ghttp.RespondWith(http.StatusOK, `welcome to zombocom`),
+							),
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/library/busybox/manifests/1.32.0"),
+								ghttp.RespondWith(http.StatusNotFound, nil),
+							),
+						)
+
+						req.Source.Repository = "busybox"
+						req.Source.RawTag = "1.32.0"
+					})
+
+					It("returns the current digest", func() {
+						Expect(res).To(Equal([]resource.Version{
+							{Digest: latestDigest(req.Source.Name())},
+						}))
+					})
 				})
 			})
 		})
@@ -142,7 +211,7 @@ var _ = Describe("Check", func() {
 
 		It("returns the given digest", func() {
 			Expect(res).To(Equal([]resource.Version{
-				{Digest: LATEST_STATIC_DIGEST},
+				*req.Version,
 			}))
 		})
 
@@ -167,55 +236,124 @@ var _ = Describe("Check", func() {
 
 			It("returns the current digest", func() {
 				Expect(res).To(Equal([]resource.Version{
-					{Digest: PRIVATE_LATEST_STATIC_DIGEST},
+					*req.Version,
 				}))
 			})
 		})
 
 		Context("against a mirror", func() {
+			var mirror *ghttp.Server
+
+			BeforeEach(func() {
+				mirror = ghttp.NewServer()
+			})
+
+			AfterEach(func() {
+				mirror.Close()
+			})
+
 			Context("which has the image", func() {
-				BeforeEach(func() {
-					req.Source = resource.Source{
-						Repository: "fakeserver.foo:5000/concourse/test-image-static",
-						RawTag:     "latest",
-
-						RegistryMirror: &resource.RegistryMirror{
+				Context("in an explicit namespace", func() {
+					BeforeEach(func() {
+						// use the mock mirror as the "origin", use Docker Hub as a "mirror"
+						req.Source.Repository = mirror.Addr() + "/" + req.Source.Repository
+						req.Source.RegistryMirror = &resource.RegistryMirror{
 							Host: name.DefaultRegistry,
-						},
-					}
+						}
+					})
 
-					req.Version = &resource.Version{
-						Digest: LATEST_STATIC_DIGEST,
-					}
+					It("returns the current digest", func() {
+						Expect(res).To(Equal([]resource.Version{
+							*req.Version,
+						}))
+					})
 				})
 
-				It("returns the current digest", func() {
-					Expect(res).To(Equal([]resource.Version{
-						{Digest: LATEST_STATIC_DIGEST},
-					}))
+				Context("in an implied namespace", func() {
+					BeforeEach(func() {
+						mirror.AppendHandlers(
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/"),
+								ghttp.RespondWith(http.StatusOK, `welcome to zombocom`),
+							),
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/library/fake-image/manifests/latest"),
+								ghttp.RespondWith(http.StatusOK, `{"fake":"manifest"}`),
+							),
+						)
+
+						req.Source.Repository = "fake-image"
+						req.Source.RegistryMirror = &resource.RegistryMirror{
+							Host: mirror.Addr(),
+						}
+
+						req.Version = &resource.Version{
+							Digest: LATEST_FAKE_DIGEST,
+						}
+					})
+
+					It("returns the current digest", func() {
+						Expect(res).To(Equal([]resource.Version{
+							*req.Version,
+						}))
+					})
 				})
 			})
 
 			Context("which is missing the image", func() {
 				BeforeEach(func() {
-					req.Source = resource.Source{
-						Repository: "concourse/test-image-static",
-						RawTag:     "latest",
-
-						RegistryMirror: &resource.RegistryMirror{
-							Host: "fakeserver.foo:5000",
-						},
-					}
-
-					req.Version = &resource.Version{
-						Digest: LATEST_STATIC_DIGEST,
+					req.Source.RegistryMirror = &resource.RegistryMirror{
+						Host: mirror.Addr(),
 					}
 				})
 
-				It("returns the current digest", func() {
-					Expect(res).To(Equal([]resource.Version{
-						{Digest: LATEST_STATIC_DIGEST},
-					}))
+				Context("in an explicit namespace", func() {
+					BeforeEach(func() {
+						mirror.AppendHandlers(
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/"),
+								ghttp.RespondWith(http.StatusOK, `welcome to zombocom`),
+							),
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/concourse/test-image-static/manifests/latest"),
+								ghttp.RespondWith(http.StatusNotFound, nil),
+							),
+						)
+					})
+
+					It("returns the current digest", func() {
+						Expect(res).To(Equal([]resource.Version{
+							*req.Version,
+						}))
+					})
+				})
+
+				Context("in an implied namespace", func() {
+					BeforeEach(func() {
+						mirror.AppendHandlers(
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/"),
+								ghttp.RespondWith(http.StatusOK, `welcome to zombocom`),
+							),
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/library/busybox/manifests/1.32.0"),
+								ghttp.RespondWith(http.StatusNotFound, nil),
+							),
+						)
+
+						req.Source.Repository = "busybox"
+						req.Source.RawTag = "1.32.0"
+
+						req.Version = &resource.Version{
+							Digest: latestDigest(req.Source.Name()),
+						}
+					})
+
+					It("returns the current digest", func() {
+						Expect(res).To(Equal([]resource.Version{
+							*req.Version,
+						}))
+					})
 				})
 			})
 		})
@@ -270,53 +408,126 @@ var _ = Describe("Check", func() {
 		})
 
 		Context("against a mirror", func() {
+			var mirror *ghttp.Server
+
+			BeforeEach(func() {
+				mirror = ghttp.NewServer()
+			})
+
+			AfterEach(func() {
+				mirror.Close()
+			})
+
 			Context("which has the image", func() {
-				BeforeEach(func() {
-					req.Source = resource.Source{
-						Repository: "fakeserver.foo:5000/concourse/test-image-static",
-						RawTag:     "latest",
-
-						RegistryMirror: &resource.RegistryMirror{
+				Context("in an explicit namespace", func() {
+					BeforeEach(func() {
+						// use the mock mirror as the "origin", use Docker Hub as a "mirror"
+						req.Source.Repository = mirror.Addr() + "/" + req.Source.Repository
+						req.Source.RegistryMirror = &resource.RegistryMirror{
 							Host: name.DefaultRegistry,
-						},
-					}
+						}
+					})
 
-					req.Version = &resource.Version{
-						// this was previously pushed to the 'latest' tag
-						Digest: OLDER_STATIC_DIGEST,
-					}
+					It("returns the current digest", func() {
+						Expect(res).To(Equal([]resource.Version{
+							{Digest: OLDER_STATIC_DIGEST},
+							{Digest: LATEST_STATIC_DIGEST},
+						}))
+					})
 				})
 
-				It("returns the current digest", func() {
-					Expect(res).To(Equal([]resource.Version{
-						{Digest: OLDER_STATIC_DIGEST},
-						{Digest: LATEST_STATIC_DIGEST},
-					}))
+				Context("in an implied namespace", func() {
+					BeforeEach(func() {
+						mirror.AppendHandlers(
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/"),
+								ghttp.RespondWith(http.StatusOK, `welcome to zombocom`),
+							),
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/library/fake-image/manifests/latest"),
+								ghttp.RespondWith(http.StatusOK, `{"fake":"manifest"}`),
+							),
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/"),
+								ghttp.RespondWith(http.StatusOK, `welcome to zombocom`),
+							),
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/library/fake-image/manifests/"+OLDER_FAKE_DIGEST),
+								ghttp.RespondWith(http.StatusOK, `{"fake":"outdated"}`),
+							),
+						)
+
+						req.Source.Repository = "fake-image"
+						req.Source.RegistryMirror = &resource.RegistryMirror{
+							Host: mirror.Addr(),
+						}
+
+						req.Version.Digest = OLDER_FAKE_DIGEST
+					})
+
+					It("returns the current digest", func() {
+						Expect(res).To(Equal([]resource.Version{
+							{Digest: OLDER_FAKE_DIGEST},
+							{Digest: LATEST_FAKE_DIGEST},
+						}))
+					})
 				})
 			})
 
 			Context("which is missing the image", func() {
 				BeforeEach(func() {
-					req.Source = resource.Source{
-						Repository: "concourse/test-image-static",
-						RawTag:     "latest",
-
-						RegistryMirror: &resource.RegistryMirror{
-							Host: "fakeserver.foo:5000",
-						},
-					}
-
-					req.Version = &resource.Version{
-						// this was previously pushed to the 'latest' tag
-						Digest: OLDER_STATIC_DIGEST,
+					req.Source.RegistryMirror = &resource.RegistryMirror{
+						Host: mirror.Addr(),
 					}
 				})
 
-				It("returns the current digest", func() {
-					Expect(res).To(Equal([]resource.Version{
-						{Digest: OLDER_STATIC_DIGEST},
-						{Digest: LATEST_STATIC_DIGEST},
-					}))
+				Context("in an explicit namespace", func() {
+					BeforeEach(func() {
+						mirror.AppendHandlers(
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/"),
+								ghttp.RespondWith(http.StatusOK, `welcome to zombocom`),
+							),
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/concourse/test-image-static/manifests/latest"),
+								ghttp.RespondWith(http.StatusNotFound, nil),
+							),
+						)
+					})
+
+					It("returns the current digest", func() {
+						Expect(res).To(Equal([]resource.Version{
+							{Digest: OLDER_STATIC_DIGEST},
+							{Digest: LATEST_STATIC_DIGEST},
+						}))
+					})
+				})
+
+				Context("in an implied namespace", func() {
+					BeforeEach(func() {
+						mirror.AppendHandlers(
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/"),
+								ghttp.RespondWith(http.StatusOK, `welcome to zombocom`),
+							),
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/library/busybox/manifests/1.32.0"),
+								ghttp.RespondWith(http.StatusNotFound, nil),
+							),
+						)
+
+						req.Source.Repository = "busybox"
+						req.Source.RawTag = "1.32.0"
+
+						req.Version.Digest = OLDER_LIBRARY_DIGEST
+					})
+
+					It("returns the current digest", func() {
+						Expect(res).To(Equal([]resource.Version{
+							{Digest: OLDER_LIBRARY_DIGEST},
+							{Digest: latestDigest(req.Source.Name())},
+						}))
+					})
 				})
 			})
 		})
@@ -363,53 +574,129 @@ var _ = Describe("Check", func() {
 		})
 
 		Context("against a mirror", func() {
-			Context("which has the image", func() {
-				BeforeEach(func() {
-					req.Source = resource.Source{
-						Repository: "fakeserver.foo:5000/concourse/test-image-static",
-						RawTag:     "latest",
+			var mirror *ghttp.Server
 
-						RegistryMirror: &resource.RegistryMirror{
+			BeforeEach(func() {
+				mirror = ghttp.NewServer()
+			})
+
+			AfterEach(func() {
+				mirror.Close()
+			})
+
+			Context("which has the image", func() {
+				Context("in an explicit namespace", func() {
+					BeforeEach(func() {
+						// use the mock mirror as the "origin", use Docker Hub as a "mirror"
+						req.Source.Repository = mirror.Addr() + "/" + req.Source.Repository
+						req.Source.RegistryMirror = &resource.RegistryMirror{
 							Host: name.DefaultRegistry,
-						},
-					}
+						}
+					})
+
+					It("returns the current digest", func() {
+						Expect(res).To(Equal([]resource.Version{
+							{Digest: LATEST_STATIC_DIGEST},
+						}))
+					})
 				})
 
-				It("returns the current digest", func() {
-					Expect(res).To(Equal([]resource.Version{
-						{Digest: LATEST_STATIC_DIGEST},
-					}))
+				Context("in an implied namespace", func() {
+					BeforeEach(func() {
+						mirror.AppendHandlers(
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/"),
+								ghttp.RespondWith(http.StatusOK, `welcome to zombocom`),
+							),
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/library/fake-image/manifests/latest"),
+								ghttp.RespondWith(http.StatusOK, `{"fake":"manifest"}`),
+							),
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/"),
+								ghttp.RespondWith(http.StatusOK, `welcome to zombocom`),
+							),
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/library/fake-image/manifests/"+req.Version.Digest),
+								ghttp.RespondWith(http.StatusNotFound, `{"errors":[{"code": "MANIFEST_UNKNOWN", "message": "ruh roh", "detail": "not here"}]}`),
+							),
+						)
+
+						req.Source.Repository = "fake-image"
+						req.Source.RegistryMirror = &resource.RegistryMirror{
+							Host: mirror.Addr(),
+						}
+					})
+
+					It("returns the current digest", func() {
+						Expect(res).To(Equal([]resource.Version{
+							{Digest: LATEST_FAKE_DIGEST},
+						}))
+					})
 				})
 			})
 
 			Context("which is missing the image", func() {
 				BeforeEach(func() {
-					req.Source = resource.Source{
-						Repository: "concourse/test-image-static",
-						RawTag:     "latest",
-
-						RegistryMirror: &resource.RegistryMirror{
-							Host: "fakeserver.foo:5000",
-						},
+					req.Source.RegistryMirror = &resource.RegistryMirror{
+						Host: mirror.Addr(),
 					}
 				})
 
-				It("returns the current digest", func() {
-					Expect(res).To(Equal([]resource.Version{
-						{Digest: LATEST_STATIC_DIGEST},
-					}))
+				Context("in an explicit namespace", func() {
+					BeforeEach(func() {
+						mirror.AppendHandlers(
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/"),
+								ghttp.RespondWith(http.StatusOK, `welcome to zombocom`),
+							),
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/concourse/test-image-static/manifests/latest"),
+								ghttp.RespondWith(http.StatusNotFound, nil),
+							),
+						)
+					})
+
+					It("returns the current digest", func() {
+						Expect(res).To(Equal([]resource.Version{
+							{Digest: LATEST_STATIC_DIGEST},
+						}))
+					})
+				})
+
+				Context("in an implied namespace", func() {
+					BeforeEach(func() {
+						mirror.AppendHandlers(
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/"),
+								ghttp.RespondWith(http.StatusOK, `welcome to zombocom`),
+							),
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/v2/library/busybox/manifests/1.32.0"),
+								ghttp.RespondWith(http.StatusNotFound, nil),
+							),
+						)
+
+						req.Source.Repository = "busybox"
+						req.Source.RawTag = "1.32.0"
+					})
+
+					It("returns the current digest", func() {
+						Expect(res).To(Equal([]resource.Version{
+							{Digest: latestDigest(req.Source.Name())},
+						}))
+					})
 				})
 			})
 		})
 	})
 
-	Context("when invoked with not exist image", func() {
+	Context("when invoked with a tag that does not exist image", func() {
 		BeforeEach(func() {
 			req.Source = resource.Source{
 				Repository: "concourse/test-image-static",
 				RawTag:     "not-exist-image",
 			}
-			req.Version = nil
 		})
 
 		It("returns empty digest", func() {

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -98,24 +98,26 @@ func main() {
 	digest := new(name.Digest)
 
 	if req.Source.RegistryMirror != nil {
-		origin := repo.Registry
+		mirror, err := name.NewRepository(repo.String())
+		if err != nil {
+			logrus.Errorf("could not resolve mirror repository: %s", err)
+			os.Exit(1)
+			return
+		}
 
-		mirror, err := name.NewRegistry(req.Source.RegistryMirror.Host, name.WeakValidation)
+		mirror.Registry, err = name.NewRegistry(req.Source.RegistryMirror.Host, name.WeakValidation)
 		if err != nil {
 			logrus.Errorf("could not resolve registry reference: %s", err)
 			os.Exit(1)
 			return
 		}
 
-		repo.Registry = mirror
-		*digest = repo.Digest(req.Version.Digest)
+		*digest = mirror.Digest(req.Version.Digest)
 
 		image, err = getWithRetry(req.Source.RegistryMirror.BasicCredentials, *digest)
 		if err != nil {
 			logrus.Warnf("fetching mirror %s failed: %s", digest.RegistryStr(), err)
 		}
-
-		repo.Registry = origin
 	}
 
 	if image == nil {

--- a/in_test.go
+++ b/in_test.go
@@ -430,47 +430,146 @@ var _ = Describe("In", func() {
 	})
 
 	Describe("uses a mirror", func() {
-		Context("which has the image", func() {
-			BeforeEach(func() {
-				req.Source.Repository = "fakeserver.foo:5000/concourse/test-image-static"
-				req.Source.RegistryMirror = &resource.RegistryMirror{
-					Host: name.DefaultRegistry,
-				}
+		var mirror *ghttp.Server
 
-				req.Version.Digest = LATEST_STATIC_DIGEST
+		BeforeEach(func() {
+			mirror = ghttp.NewServer()
+		})
+
+		AfterEach(func() {
+			mirror.Close()
+		})
+
+		Context("which has the image", func() {
+			Context("in an explicit namespace", func() {
+				BeforeEach(func() {
+					// use the mock mirror as the "origin", use Docker Hub as a "mirror"
+					req.Source.Repository = mirror.Addr() + "/concourse/test-image-static"
+					req.Source.RegistryMirror = &resource.RegistryMirror{
+						Host: name.DefaultRegistry,
+					}
+
+					req.Version.Digest = LATEST_STATIC_DIGEST
+				})
+
+				It("saves the rootfs and metadata", func() {
+					_, err := os.Stat(rootfsPath("Dockerfile"))
+					Expect(err).ToNot(HaveOccurred())
+
+					_, err = ioutil.ReadFile(filepath.Join(destDir, "digest"))
+					Expect(err).ToNot(HaveOccurred())
+
+					_, err = ioutil.ReadFile(filepath.Join(destDir, "tag"))
+					Expect(err).ToNot(HaveOccurred())
+				})
 			})
 
-			It("saves the rootfs and metadata", func() {
-				_, err := os.Stat(rootfsPath("Dockerfile"))
-				Expect(err).ToNot(HaveOccurred())
+			Context("in an implied namespace", func() {
+				BeforeEach(func() {
+					fakeImage := empty.Image
 
-				_, err = ioutil.ReadFile(filepath.Join(destDir, "digest"))
-				Expect(err).ToNot(HaveOccurred())
+					digest, err := fakeImage.Digest()
+					Expect(err).ToNot(HaveOccurred())
 
-				_, err = ioutil.ReadFile(filepath.Join(destDir, "tag"))
-				Expect(err).ToNot(HaveOccurred())
+					manifest, err := fakeImage.RawManifest()
+					Expect(err).ToNot(HaveOccurred())
+
+					config, err := fakeImage.RawConfigFile()
+					Expect(err).ToNot(HaveOccurred())
+
+					configDigest, err := fakeImage.ConfigName()
+					Expect(err).ToNot(HaveOccurred())
+
+					mirror.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/v2/"),
+							ghttp.RespondWith(http.StatusOK, `welcome to zombocom`),
+						),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/v2/library/fake-image/manifests/"+digest.String()),
+							ghttp.RespondWith(http.StatusOK, manifest),
+						),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/v2/library/fake-image/blobs/"+configDigest.String()),
+							ghttp.RespondWith(http.StatusOK, config),
+						),
+					)
+
+					req.Source = resource.Source{
+						Repository: "fake-image",
+						RegistryMirror: &resource.RegistryMirror{
+							Host: mirror.Addr(),
+						},
+					}
+
+					req.Version.Digest = digest.String()
+				})
+
+				It("pulls the image from the library", func() {
+					Expect(res.Version).To(Equal(req.Version))
+				})
 			})
 		})
 
 		Context("which is missing the image", func() {
 			BeforeEach(func() {
-				req.Source.Repository = "concourse/test-image-static"
 				req.Source.RegistryMirror = &resource.RegistryMirror{
-					Host: "fakeserver.foo:5000",
+					Host: mirror.Addr(),
 				}
-
-				req.Version.Digest = LATEST_STATIC_DIGEST
 			})
 
-			It("saves the rootfs and metadata", func() {
-				_, err := os.Stat(rootfsPath("Dockerfile"))
-				Expect(err).ToNot(HaveOccurred())
+			Context("in an explicit namespace", func() {
+				BeforeEach(func() {
+					req.Source.Repository = "concourse/test-image-static"
 
-				_, err = ioutil.ReadFile(filepath.Join(destDir, "digest"))
-				Expect(err).ToNot(HaveOccurred())
+					req.Version.Digest = LATEST_STATIC_DIGEST
 
-				_, err = ioutil.ReadFile(filepath.Join(destDir, "tag"))
-				Expect(err).ToNot(HaveOccurred())
+					mirror.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/v2/"),
+							ghttp.RespondWith(http.StatusOK, `welcome to zombocom`),
+						),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/v2/concourse/test-image-static/manifests/"+req.Version.Digest),
+							ghttp.RespondWith(http.StatusNotFound, nil),
+						),
+					)
+				})
+
+				It("saves the rootfs and metadata", func() {
+					_, err := os.Stat(rootfsPath("Dockerfile"))
+					Expect(err).ToNot(HaveOccurred())
+
+					_, err = ioutil.ReadFile(filepath.Join(destDir, "digest"))
+					Expect(err).ToNot(HaveOccurred())
+
+					_, err = ioutil.ReadFile(filepath.Join(destDir, "tag"))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			Context("in an implied namespace", func() {
+				BeforeEach(func() {
+					req.Source.Repository = "busybox"
+
+					req.Version.Digest = latestDigest(req.Source.Repository)
+
+					mirror.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/v2/"),
+							ghttp.RespondWith(http.StatusOK, `welcome to zombocom`),
+						),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/v2/library/busybox/manifests/"+req.Version.Digest),
+							ghttp.RespondWith(http.StatusNotFound, nil),
+						),
+					)
+
+				})
+
+				It("pulls the image from the library", func() {
+					Expect(res.Version).To(Equal(req.Version))
+				})
 			})
 		})
 	})

--- a/suite_test.go
+++ b/suite_test.go
@@ -20,6 +20,12 @@ var bins struct {
 	Check string `json:"check"`
 }
 
+// sha256 of {"fake":"outdated"} and {"fake":"manifest"}
+const OLDER_FAKE_DIGEST = "sha256:f5361183777fc8973760829d7cd24c37e3fab6d86c8fe6ae42851c305805c01b"
+const LATEST_FAKE_DIGEST = "sha256:c4c25c2cd70e3071f08cf124c4b5c656c061dd38247d166d97098d58eeea8aa6"
+
+const OLDER_LIBRARY_DIGEST = "sha256:2131f09e4044327fd101ca1fd4043e6f3ad921ae7ee901e9142e6e36b354a907"
+
 // see testdata/static/Dockerfile
 const OLDER_STATIC_DIGEST = "sha256:7dabedca9d367a71d1cd646bd8d79f14de7b07327e4417ab691f5f13be5647a9"
 const LATEST_STATIC_DIGEST = "sha256:fc484c7e21a5616c600778d7ee720b3adfe1373c896be4f068c3da4a205d4a2e"


### PR DESCRIPTION
closes #231 (supersedes it)

Per [the comment](https://github.com/concourse/registry-image-resource/pull/183#issuecomment-662833877) from @evanchaoli, pulling _**Docker Official Images**_ from a mirror fails since Docker Hub (the origin) organizes these images in a common namespace: _library_.

When digging in to this a bit further, it turns out that specifying a mirror with an invalid address handles some scenarios (such a low-level network failures) but can't emulate higher-level failures (such as a `404` with a response body) which are legitimate scenarios and have different paths through the code.

This PR address the concern raised in #183 around implicit namespaces and converts the unit tests for mirror scenarios to use a mocked up HTTP server as the mirror repository.

cc: @vito, as I think this throws a bit of a 🔧  in to #214 