### PR TITLE
registry_mirror no longer overwrites a repo host

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ differences:
   and debugging output will be printed instead.
 
 * `registry_mirror`: *Optional.*
-  * `host`: *Required.* A hostname pointing to a Docker registry mirror service.
+  * `host`: *Required.* A hostname pointing to a Docker registry mirror service. Note that this is only used if no registry hostname prefix is specified in the `repository`. If the `repository` contains a registry hostname prefix -- such as `my-registry.com/foo/bar` -- the `registry_mirror` is ignored and the explicitly declared registry in the `repository` value is used.
   * `username` and `password`: *Optional.* A username and password to use when
   authenticating to the mirror.
 

--- a/commands/check.go
+++ b/commands/check.go
@@ -68,7 +68,9 @@ func (c *check) Execute() error {
 	var response CheckResponse
 	tag := new(name.Tag)
 
-	if req.Source.RegistryMirror != nil {
+	// only use the RegistryMirror as the Registry if the repo doesn't use a different,
+	// explicitly-declared, non-default registry, such as 'some-registry.com/foo/bar'.
+	if req.Source.RegistryMirror != nil && repo.Registry.String() == name.DefaultRegistry {
 		mirror, err := name.NewRepository(repo.String())
 		if err != nil {
 			return fmt.Errorf("could not resolve mirror repository: %s", err)


### PR DESCRIPTION
Fixes issue #247.

This ensures that, even if a `registry_mirror` is
configured, images whose `source.repository` contains
an explicitly declared registry-host-prefixed image
(such as `my-registry.com/foo/bar`) will be checked at
and fetched from the explicitly declared registry,
and not at the `source.registry_mirror`.

Signed-off-by: Mike Ball <mikedball@gmail.com>