### PR TITLE
check: try GET when HEAD request returns no digest

### DIFF
--- a/suite_test.go
+++ b/suite_test.go
@@ -3,7 +3,9 @@ package resource_test
 import (
 	"encoding/json"
 	"io/ioutil"
+	"net/http"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -23,6 +25,16 @@ var bins struct {
 // sha256 of {"fake":"outdated"} and {"fake":"manifest"}
 const OLDER_FAKE_DIGEST = "sha256:f5361183777fc8973760829d7cd24c37e3fab6d86c8fe6ae42851c305805c01b"
 const LATEST_FAKE_DIGEST = "sha256:c4c25c2cd70e3071f08cf124c4b5c656c061dd38247d166d97098d58eeea8aa6"
+
+var OLDER_FAKE_HEADERS = http.Header{
+	"Docker-Content-Digest": {OLDER_FAKE_DIGEST},
+	"Content-Length":        {strconv.Itoa(len(`{"fake":"manifest"}`))},
+}
+
+var LATEST_FAKE_HEADERS = http.Header{
+	"Docker-Content-Digest": {LATEST_FAKE_DIGEST},
+	"Content-Length":        {strconv.Itoa(len(`{"fake":"outdated"}`))},
+}
 
 const OLDER_LIBRARY_DIGEST = "sha256:2131f09e4044327fd101ca1fd4043e6f3ad921ae7ee901e9142e6e36b354a907"
 


### PR DESCRIPTION
some registries don't return Docker-Content-Digest, so in that scenario we'll need to fetch the actual manifest

context: https://github.com/concourse/docker-image-resource/pull/307, https://github.com/concourse/docker-image-resource/pull/308