### PR TITLE
RFC: Use default key chain for authentication to the registry

### DIFF
--- a/commands/check.go
+++ b/commands/check.go
@@ -117,6 +117,8 @@ func performCheck(principal resource.BasicCredentials, version *resource.Version
 
 	if auth.Username != "" && auth.Password != "" {
 		imageOpts = append(imageOpts, remote.WithAuth(auth))
+	} else {
+		imageOpts = append(imageOpts, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 	}
 
 	digest, found, err := headOrGet(ref, imageOpts...)

--- a/commands/in.go
+++ b/commands/in.go
@@ -181,6 +181,8 @@ func get(principal resource.BasicCredentials, digest name.Digest) (v1.Image, err
 
 	if auth.Username != "" && auth.Password != "" {
 		imageOpts = append(imageOpts, remote.WithAuth(auth))
+	} else {
+		imageOpts = append(imageOpts, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 	}
 
 	image, err := remote.Image(digest, imageOpts...)


### PR DESCRIPTION
This should allow simple specialisations of the resource to allow for specific container registry variants without changing the existing behaviour.

For example, to use this with GCR the existing registry-image image can be used as a base layer and then we can copy in a ~/.docker/config.json and optionally a credential manager to authenticate.

Our use case:

We exclusively use google container registry and currently authenticate using the `_json_key:service_account.json` hack described here https://github.com/concourse/docker-image-resource/issues/73#issuecomment-255165396.
A big drawback of this approach is that a developer can read this secret by printing it out in a task.
We want to be reasonably sure that any images that are stored in our production container registry have been built by Concourse so that we have some sort of an audit trail for what has been used to build the image. One approach to achieve this is to use the VM service account / application default credentials to authenticate. Ordinarily you would achieve this by using a credential manager and a docker configuration file.

For the `oci-build-task` and `docker-registry` resources we have a partial hack in place that does just that. i.e. a Dockerfile containing

```
ARG VERSION=latest
FROM vito/oci-build-task:$VERSION

COPY docker-credential-gcr /usr/local/bin/
COPY config.json /root/.docker/config.json
```
and a config file containing:
```
{
  "credHelpers": {
    "eu.gcr.io": "gcr"
  }
}
```

However, the `check` stage of the docker-registry resource does not work with this as it doesn't use docker directly. We'd like to get away from the docker-registry resource either way given that development is frozen on it and it is deprecated.

This PR is largely untested, but I would like some feedback on the approach before continuing.