### PR TITLE
Write repository string to file on get step

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ Fetches an image at the exact digest specified by the version.
 
 The resource will produce the following files:
 
+* `./repository`: A file containing the image's full repository name, e.g. `concourse/concourse`. 
+  For ECR images, this will include the registry the image was pulled from.
 * `./tag`: A file containing the tag from the version.
 * `./digest`: A file containing the digest from the version, e.g. `sha256:...`.
 

--- a/commands/in.go
+++ b/commands/in.go
@@ -101,7 +101,7 @@ func (i *In) Execute() error {
 		}
 	}
 
-	err = saveVersionInfo(dest, req.Version)
+	err = saveVersionInfo(dest, req.Version, req.Source.Repository)
 	if err != nil {
 		return fmt.Errorf("saving version info failed: %w", err)
 	}
@@ -165,7 +165,7 @@ func saveImage(dest string, tag name.Tag, image v1.Image, format string, debug b
 	return nil
 }
 
-func saveVersionInfo(dest string, version resource.Version) error {
+func saveVersionInfo(dest string, version resource.Version, repo string) error {
 	err := ioutil.WriteFile(filepath.Join(dest, "tag"), []byte(version.Tag), 0644)
 	if err != nil {
 		return fmt.Errorf("write image tag: %w", err)
@@ -174,6 +174,11 @@ func saveVersionInfo(dest string, version resource.Version) error {
 	err = ioutil.WriteFile(filepath.Join(dest, "digest"), []byte(version.Digest), 0644)
 	if err != nil {
 		return fmt.Errorf("write image digest: %w", err)
+	}
+
+	err = ioutil.WriteFile(filepath.Join(dest, "repository"), []byte(repo), 0644)
+	if err != nil {
+		return fmt.Errorf("write image repository: %w", err)
 	}
 
 	return nil

--- a/in_test.go
+++ b/in_test.go
@@ -335,6 +335,20 @@ var _ = Describe("In", func() {
 		})
 	})
 
+	Describe("saving the repository", func() {
+		BeforeEach(func() {
+			req.Source.Repository = "concourse/test-image-static"
+			req.Version.Tag = "latest"
+			req.Version.Digest = LATEST_STATIC_DIGEST
+		})
+
+		It("saves the repository string to a file", func() {
+			digest, err := ioutil.ReadFile(filepath.Join(destDir, "repository"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(digest)).To(Equal("concourse/test-image-static"))
+		})
+	})
+
 	Describe("skipping the download", func() {
 		BeforeEach(func() {
 			req.Source.Repository = "concourse/test-image-static"

--- a/in_test.go
+++ b/in_test.go
@@ -343,9 +343,9 @@ var _ = Describe("In", func() {
 		})
 
 		It("saves the repository string to a file", func() {
-			digest, err := ioutil.ReadFile(filepath.Join(destDir, "repository"))
+			repository, err := ioutil.ReadFile(filepath.Join(destDir, "repository"))
 			Expect(err).ToNot(HaveOccurred())
-			Expect(string(digest)).To(Equal("concourse/test-image-static"))
+			Expect(string(repository)).To(Equal("concourse/test-image-static"))
 		})
 	})
 


### PR DESCRIPTION
When dealing with registries other than Docker Hub, it can be useful to have the full repository name including the registry available to the Concourse pipeline.

Alongside `image/tag` and `image/digest`, this PR makes the resource write the source's repository value to `image/repository`.
For any image fetches which modify the `Source.Repository` value (such as ECR), this ensures we can obtain the full repository string including the registry for use later in the pipeline.
