### PR TITLE
Optionally allow out version to be specified in a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,8 @@ Tags may be specified in multiple ways:
 * `image`: *Required.* The path to the OCI image tarball to upload. Expanded
   with [`filepath.Glob`](https://golang.org/pkg/path/filepath/#Glob).
 
-* `version`: *Optional.* A version number to use as a tag.
+* `version`: *Optional.* A version number to use as a tag (can be a version string
+  or a path to file containing the version number).
 
 * `bump_aliases`: *Optional. Default `false`.* When set to `true` and `version`
   is specified, automatically bump alias tags for the version.

--- a/out_test.go
+++ b/out_test.go
@@ -247,6 +247,40 @@ var _ = Describe("Out", func() {
 			})
 		})
 
+		Context("with version provided as a file", func() {
+			BeforeEach(func() {
+				req.Params.Version = "version-file"
+
+				err := ioutil.WriteFile(
+					filepath.Join(srcDir, req.Params.Version),
+					[]byte("0.8.0"),
+					0644,
+				)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("pushes provided version as the tag", func() {
+				randomDigest, err := randomImage.Digest()
+				Expect(err).ToNot(HaveOccurred())
+
+				name, err := name.ParseReference(req.Source.Repository + ":0.8.0")
+				Expect(err).ToNot(HaveOccurred())
+
+				auth := &authn.Basic{
+					Username: req.Source.Username,
+					Password: req.Source.Password,
+				}
+
+				image, err := remote.Image(name, remote.WithAuth(auth))
+				Expect(err).ToNot(HaveOccurred())
+
+				pushedDigest, err := image.Digest()
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(pushedDigest).To(Equal(randomDigest))
+			})
+		})
+
 		Context("with additional_tags (newline separator)", func() {
 			BeforeEach(func() {
 				req.Params.AdditionalTags = "tags"


### PR DESCRIPTION
This will allow pushing a tagged image to be combined with the semver resource, for example.