### PR TITLE
Add support for AWS IAM roles chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,12 @@ differences:
 * `aws_region`: *Optional. Default `""`.* The region to use for accessing ECR. This is required if you are using ECR. This region will help determine the full repository URL you are accessing (e.g., `012345678910.dkr.ecr.us-east-1.amazonaws.com`)
 
 * `aws_role_arn`: *Optional. Default `""`.* If set, then this role will be
-  assumed before authenticating to ECR.
+   assumed before authenticating to ECR. An error will occur if `aws_role_arns`
+   is also specified. This is kept for backward compatibility.
+
+* `aws_role_arns`: *Optional. Default `""`.* An array of AWS IAM roles.
+  If set, these roles will be assumed in the specified order before authenticating to ECR.
+  An error will occur if `aws_role_arn` is also specified.
 
 * `debug`: *Optional. Default `false`.* If set, progress bars will be disabled
   and debugging output will be printed instead.
@@ -110,7 +115,7 @@ differences:
   This is used to validate the certificate of the docker registry when the
   registry's certificate is signed by a custom authority (or itself).
 
-### Signing with Docker Hub 
+### Signing with Docker Hub
 
 Configure Docker Content Trust for use with the [Docker Hub](https:/hub.docker.io) and Notary service by specifying the above source parameters as follows:
 
@@ -265,7 +270,7 @@ Fetches an image at the exact digest specified by the version.
 
 The resource will produce the following files:
 
-* `./repository`: A file containing the image's full repository name, e.g. `concourse/concourse`. 
+* `./repository`: A file containing the image's full repository name, e.g. `concourse/concourse`.
   For ECR images, this will include the registry the image was pulled from.
 * `./tag`: A file containing the tag from the version.
 * `./digest`: A file containing the digest from the version, e.g. `sha256:...`.


### PR DESCRIPTION
In certain scenarios, a shared Concourse is run in a separate AWS
account (Account C) and needs to assume a role in a different AWS
account (Account A) in order to do the concourse tasks. The ECR is
located in another AWS account: Account E. Only Account A has access to
Account E. Therefore for registry-image to access ECR using the Account
C credentials, it needs to assume a role in Account A; which allows
assuming a role in Account E to have access to the ECR.

This PR introduces a new parameter: `aws_role_arns` which takes a an
array of IAM roles to be assumed in the order specified.

Users can still use the previous `aws_role_arn` that we kept for
backward compatibility but if both are specified, an error will be
thrown by the resource.

The following local test were performed locally:
1. iam roles chain (new feature)
2. error if both `aws_role_arn` and `aws_role_arns` are set
2. only `aws_role_arn` specified (backward compatibility)

Signed-off-by: Frederic Francois <frederic.francois@digital.cabinet-office.gov.uk>