### PR TITLE
Include labels in metadata.json

### DIFF
--- a/commands/in.go
+++ b/commands/in.go
@@ -19,8 +19,9 @@ import (
 )
 
 type ImageMetadata struct {
-	Env  []string `json:"env"`
-	User string   `json:"user"`
+	Env    []string          `json:"env"`
+	User   string            `json:"user"`
+	Labels map[string]string `json:"labels"`
 }
 
 type In struct {
@@ -210,13 +211,10 @@ func rootfsFormat(dest string, image v1.Image, debug bool, stderr io.Writer) err
 		return fmt.Errorf("create image metadata: %w", err)
 	}
 
-	env := cfg.Config.Env
-
-	user := cfg.Config.User
-
 	err = json.NewEncoder(meta).Encode(ImageMetadata{
-		Env:  env,
-		User: user,
+		Env:    cfg.Config.Env,
+		User:   cfg.Config.User,
+		Labels: cfg.Config.Labels,
 	})
 	if err != nil {
 		return fmt.Errorf("write image metadata: %w", err)


### PR DESCRIPTION
Hi all, this small change adds the image's labels to the `metadata.json` file that's produced for the `rootfs` format. This is useful for us as we can include things like VCS metadata in the labels which can be used in tasks.