### PR TITLE
Add AWS Instance Profile authentication support for AWS ECR

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ differences:
   using `put`.
 
 * `aws_access_key_id`: *Optional. Default `""`.* The access key ID to use for
-  authenticating with ECR.
+  authenticating with ECR.  When using Instance Profiles this can be left blank.
 
 * `aws_secret_access_key`: *Optional. Default `""`.* The secret access key to
-  use for authenticating with ECR.
+  use for authenticating with ECR.  When using Instance Profiles this can be left blank.
 
 * `aws_session_token`: *Optional. Default `""`.* The session token to use
   for authenticating with STS credentials with ECR.

--- a/commands/check.go
+++ b/commands/check.go
@@ -49,7 +49,9 @@ func (c *Check) Execute() error {
 		return fmt.Errorf("invalid payload: %s", err)
 	}
 
-	if req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "" {
+	// Only the aws region is mandatory for ECR authentication
+	// Instance Profiles, for example, do not require Access Keys and Secrets
+	if req.Source.AwsRegion != "" {
 		if !req.Source.AuthenticateToECR() {
 			return fmt.Errorf("cannot authenticate with ECR")
 		}

--- a/commands/in.go
+++ b/commands/in.go
@@ -65,7 +65,9 @@ func (i *In) Execute() error {
 
 	dest := i.args[1]
 
-	if req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "" {
+	// Only the aws region is mandatory for ECR authentication
+	// Instance Profiles, for example, do not require Access Keys and Secrets
+	if req.Source.AwsRegion != "" {
 		if !req.Source.AuthenticateToECR() {
 			return fmt.Errorf("cannot authenticate with ECR")
 		}

--- a/commands/out.go
+++ b/commands/out.go
@@ -63,7 +63,9 @@ func (o *Out) Execute() error {
 
 	src := o.args[1]
 
-	if req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "" {
+	// Only the aws region is mandatory for ECR authentication
+	// Instance Profiles, for example, do not require Access Keys and Secrets
+	if req.Source.AwsRegion != "" {
 		if !req.Source.AuthenticateToECR() {
 			return fmt.Errorf("cannot authenticate with ECR")
 		}

--- a/types.go
+++ b/types.go
@@ -285,10 +285,19 @@ func (source *Source) AuthenticateToECR() bool {
 		return false
 	}
 
-	mySession := session.Must(session.NewSession(&aws.Config{
-		Region:      aws.String(source.AwsRegion),
-		Credentials: credentials.NewStaticCredentials(source.AwsAccessKeyId, source.AwsSecretAccessKey, source.AwsSessionToken),
-	}))
+	var mySession *session.Session
+
+	if source.AwsAccessKeyId != "" && source.AwsSecretAccessKey != "" {
+		mySession = session.Must(session.NewSession(&aws.Config{
+			Region:      aws.String(source.AwsRegion),
+			Credentials: credentials.NewStaticCredentials(source.AwsAccessKeyId, source.AwsSecretAccessKey, source.AwsSessionToken),
+		}))
+	} else {
+		// Without an access key id or secret access key we assume an Instance Profile is being used
+		mySession = session.Must(session.NewSession(&aws.Config{
+			Region:      aws.String(source.AwsRegion),
+		}))
+	}
 
 	// Note: This implementation gives precedence to `aws_role_arn` since it
 	// assumes that we've errored if both `aws_role_arn` and `aws_role_arns`


### PR DESCRIPTION
Following AWS Best Practice, we use Instance Profiles on our EC2 nodes that run concourse.

By avoiding passing Credentials to the aws.Config, it allows the registry-image-resource to use Instance Profiles authentication, so we can avoid having to create and manages access keys.

