### PR TITLE
Add aws_use_instance_role flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 testdata/.push-output
 .envrc
 tags
+.idea

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ differences:
   If set, these roles will be assumed in the specified order before authenticating to ECR.
   An error will occur if `aws_role_arn` is also specified.
 
-  `aws_use_instance_role`: *Optional. Default `""`.* If set to `true` the EC2 Iam role will be used, `aws_region` must be set. If this is set `aws_role_arn` and `aws_role_arns` will be ignored. 
+* `aws_use_instance_role`: *Optional. Default `""`.* If set to `true` the EC2 Iam role will be used, `aws_region` must be set. If this is set `aws_role_arn` and `aws_role_arns` will be ignored. 
 
 * `debug`: *Optional. Default `false`.* If set, progress bars will be disabled
   and debugging output will be printed instead.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ differences:
   If set, these roles will be assumed in the specified order before authenticating to ECR.
   An error will occur if `aws_role_arn` is also specified.
 
+  `aws_use_instance_role`: *Optional. Default `""`.* If set to `true` the EC2 Iam role will be used, `aws_region` must be set. If this is set `aws_role_arn` and `aws_role_arns` will be ignored. 
+
 * `debug`: *Optional. Default `false`.* If set, progress bars will be disabled
   and debugging output will be printed instead.
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ differences:
   If set, these roles will be assumed in the specified order before authenticating to ECR.
   An error will occur if `aws_role_arn` is also specified.
 
-* `aws_use_instance_role`: *Optional. Default `""`.* If set to `true` the EC2 Iam role will be used, `aws_region` must be set. If this is set `aws_role_arn` and `aws_role_arns` will be ignored. 
+* `aws_use_instance_role`: *Optional. Default `false`.* If set to `true` the EC2 Iam role will be used, `aws_region` must be set. If this is set `aws_role_arn` and `aws_role_arns` will be ignored. 
 
 * `debug`: *Optional. Default `false`.* If set, progress bars will be disabled
   and debugging output will be printed instead.

--- a/commands/check.go
+++ b/commands/check.go
@@ -49,7 +49,7 @@ func (c *Check) Execute() error {
 		return fmt.Errorf("invalid payload: %s", err)
 	}
 
-	if (req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "") || (req.Source.AwsRegion != "" && req.Source.AwsUseInstanceRole) {
+	if (req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "") || (req.Source.AwsRegion != "" && req.Source.AwsUseInstanceRole == "true") {
 		if !req.Source.AuthenticateToECR() {
 			return fmt.Errorf("cannot authenticate with ECR")
 		}

--- a/commands/check.go
+++ b/commands/check.go
@@ -49,7 +49,7 @@ func (c *Check) Execute() error {
 		return fmt.Errorf("invalid payload: %s", err)
 	}
 
-	if req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "" {
+	if (req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "") || (req.Source.AwsRegion != "" && req.Source.AwsUseInstanceRole) {
 		if !req.Source.AuthenticateToECR() {
 			return fmt.Errorf("cannot authenticate with ECR")
 		}

--- a/commands/check.go
+++ b/commands/check.go
@@ -49,7 +49,7 @@ func (c *Check) Execute() error {
 		return fmt.Errorf("invalid payload: %s", err)
 	}
 
-	if (req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "") || (req.Source.AwsRegion != "" && req.Source.AwsUseInstanceRole == "true") {
+	if (req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "") || (req.Source.AwsRegion != "" && req.Source.AwsUseInstanceRole) {
 		if !req.Source.AuthenticateToECR() {
 			return fmt.Errorf("cannot authenticate with ECR")
 		}

--- a/commands/in.go
+++ b/commands/in.go
@@ -65,7 +65,7 @@ func (i *In) Execute() error {
 
 	dest := i.args[1]
 
-	if (req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "") || (req.Source.AwsRegion != "" && req.Source.AwsUseInstanceRole == "true") {
+	if (req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "") || (req.Source.AwsRegion != "" && req.Source.AwsUseInstanceRole) {
 		if !req.Source.AuthenticateToECR() {
 			return fmt.Errorf("cannot authenticate with ECR")
 		}

--- a/commands/in.go
+++ b/commands/in.go
@@ -65,7 +65,7 @@ func (i *In) Execute() error {
 
 	dest := i.args[1]
 
-	if (req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "") || (req.Source.AwsRegion != "" && req.Source.AwsUseInstanceRole) {
+	if (req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "") || (req.Source.AwsRegion != "" && req.Source.AwsUseInstanceRole == "true") {
 		if !req.Source.AuthenticateToECR() {
 			return fmt.Errorf("cannot authenticate with ECR")
 		}

--- a/commands/in.go
+++ b/commands/in.go
@@ -65,7 +65,7 @@ func (i *In) Execute() error {
 
 	dest := i.args[1]
 
-	if req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "" {
+	if (req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "") || (req.Source.AwsRegion != "" && req.Source.AwsUseInstanceRole) {
 		if !req.Source.AuthenticateToECR() {
 			return fmt.Errorf("cannot authenticate with ECR")
 		}

--- a/commands/out.go
+++ b/commands/out.go
@@ -63,7 +63,7 @@ func (o *Out) Execute() error {
 
 	src := o.args[1]
 
-	if (req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "") || (req.Source.AwsRegion != "" && req.Source.AwsUseInstanceRole) {
+	if (req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "") || (req.Source.AwsRegion != "" && req.Source.AwsUseInstanceRole == "true") {
 		if !req.Source.AuthenticateToECR() {
 			return fmt.Errorf("cannot authenticate with ECR")
 		}

--- a/commands/out.go
+++ b/commands/out.go
@@ -63,7 +63,7 @@ func (o *Out) Execute() error {
 
 	src := o.args[1]
 
-	if (req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "") || (req.Source.AwsRegion != "" && req.Source.AwsUseInstanceRole) {
+	if (req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "") || (req.Source.AwsRegion != "" && req.Source.AwsUseInstanceRole == true) {
 		if !req.Source.AuthenticateToECR() {
 			return fmt.Errorf("cannot authenticate with ECR")
 		}

--- a/commands/out.go
+++ b/commands/out.go
@@ -63,7 +63,7 @@ func (o *Out) Execute() error {
 
 	src := o.args[1]
 
-	if (req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "") || (req.Source.AwsRegion != "" && req.Source.AwsUseInstanceRole == true) {
+	if (req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "") || (req.Source.AwsRegion != "" && req.Source.AwsUseInstanceRole) {
 		if !req.Source.AuthenticateToECR() {
 			return fmt.Errorf("cannot authenticate with ECR")
 		}

--- a/commands/out.go
+++ b/commands/out.go
@@ -63,7 +63,7 @@ func (o *Out) Execute() error {
 
 	src := o.args[1]
 
-	if (req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "") || (req.Source.AwsRegion != "" && req.Source.AwsUseInstanceRole == "true") {
+	if (req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "") || (req.Source.AwsRegion != "" && req.Source.AwsUseInstanceRole) {
 		if !req.Source.AuthenticateToECR() {
 			return fmt.Errorf("cannot authenticate with ECR")
 		}

--- a/commands/out.go
+++ b/commands/out.go
@@ -63,7 +63,7 @@ func (o *Out) Execute() error {
 
 	src := o.args[1]
 
-	if req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "" {
+	if (req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "") || (req.Source.AwsRegion != "" && req.Source.AwsUseInstanceRole) {
 		if !req.Source.AuthenticateToECR() {
 			return fmt.Errorf("cannot authenticate with ECR")
 		}

--- a/types.go
+++ b/types.go
@@ -62,7 +62,7 @@ type AwsCredentials struct {
 	AWSECRRegistryId   string   `json:"aws_ecr_registry_id,omitempty"`
 	AwsRoleArn         string   `json:"aws_role_arn,omitempty"`
 	AwsRoleArns        []string `json:"aws_role_arns,omitempty"`
-	AwsUseInstanceRole string   `json:"aws_use_instance_role,omitempty"`
+	AwsUseInstanceRole string   `json:"aws_use_instance_role"`
 }
 
 type BasicCredentials struct {
@@ -306,7 +306,7 @@ func (source *Source) AuthenticateToECR() bool {
 	}))
 
 	// Override mySession if aws_use_instance_role is set
-	if source.AwsUseInstanceRole == "true" {
+	if source.AwsUseInstanceRole {
 		mySession = session.Must(session.NewSession(&aws.Config{
 			Region: aws.String(source.AwsRegion)}))
 	}

--- a/types.go
+++ b/types.go
@@ -62,6 +62,7 @@ type AwsCredentials struct {
 	AWSECRRegistryId   string   `json:"aws_ecr_registry_id,omitempty"`
 	AwsRoleArn         string   `json:"aws_role_arn,omitempty"`
 	AwsRoleArns        []string `json:"aws_role_arns,omitempty"`
+	AwsUseInstanceRole bool     `json:"aws_use_instance_role,omitempty"`
 }
 
 type BasicCredentials struct {
@@ -299,10 +300,15 @@ func (source *Source) AuthenticateToECR() bool {
 		return false
 	}
 
-	mySession := session.Must(session.NewSession(&aws.Config{
-		Region:      aws.String(source.AwsRegion),
-		Credentials: credentials.NewStaticCredentials(source.AwsAccessKeyId, source.AwsSecretAccessKey, source.AwsSessionToken),
-	}))
+	if !source.AwsUseInstanceRole {
+		mySession := session.Must(session.NewSession(&aws.Config{
+			Region:      aws.String(source.AwsRegion),
+			Credentials: credentials.NewStaticCredentials(source.AwsAccessKeyId, source.AwsSecretAccessKey, source.AwsSessionToken),
+		}))
+	else {
+		mySession := session.Must(session.NewSession(&aws.Config{
+			Region:      aws.String(source.AwsRegion)}))
+	}
 
 	// Note: This implementation gives precedence to `aws_role_arn` since it
 	// assumes that we've errored if both `aws_role_arn` and `aws_role_arns`

--- a/types.go
+++ b/types.go
@@ -62,7 +62,7 @@ type AwsCredentials struct {
 	AWSECRRegistryId   string   `json:"aws_ecr_registry_id,omitempty"`
 	AwsRoleArn         string   `json:"aws_role_arn,omitempty"`
 	AwsRoleArns        []string `json:"aws_role_arns,omitempty"`
-	AwsUseInstanceRole bool     `json:"aws_use_instance_role,omitempty"`
+	AwsUseInstanceRole string   `json:"aws_use_instance_role,omitempty"`
 }
 
 type BasicCredentials struct {
@@ -300,14 +300,15 @@ func (source *Source) AuthenticateToECR() bool {
 		return false
 	}
 
-	if !source.AwsUseInstanceRole {
-		mySession := session.Must(session.NewSession(&aws.Config{
-			Region:      aws.String(source.AwsRegion),
-			Credentials: credentials.NewStaticCredentials(source.AwsAccessKeyId, source.AwsSecretAccessKey, source.AwsSessionToken),
-		}))
-	else {
-		mySession := session.Must(session.NewSession(&aws.Config{
-			Region:      aws.String(source.AwsRegion)}))
+	mySession := session.Must(session.NewSession(&aws.Config{
+		Region:      aws.String(source.AwsRegion),
+		Credentials: credentials.NewStaticCredentials(source.AwsAccessKeyId, source.AwsSecretAccessKey, source.AwsSessionToken),
+	}))
+
+	// Override mySession if aws_use_instance_role is set
+	if source.AwsUseInstanceRole == "true" {
+		mySession = session.Must(session.NewSession(&aws.Config{
+			Region: aws.String(source.AwsRegion)}))
 	}
 
 	// Note: This implementation gives precedence to `aws_role_arn` since it

--- a/types.go
+++ b/types.go
@@ -62,7 +62,7 @@ type AwsCredentials struct {
 	AWSECRRegistryId   string   `json:"aws_ecr_registry_id,omitempty"`
 	AwsRoleArn         string   `json:"aws_role_arn,omitempty"`
 	AwsRoleArns        []string `json:"aws_role_arns,omitempty"`
-	AwsUseInstanceRole string   `json:"aws_use_instance_role"`
+	AwsUseInstanceRole bool     `json:"aws_use_instance_role"`
 }
 
 type BasicCredentials struct {

--- a/types.go
+++ b/types.go
@@ -62,7 +62,7 @@ type AwsCredentials struct {
 	AWSECRRegistryId   string   `json:"aws_ecr_registry_id,omitempty"`
 	AwsRoleArn         string   `json:"aws_role_arn,omitempty"`
 	AwsRoleArns        []string `json:"aws_role_arns,omitempty"`
-	AwsUseInstanceRole bool     `json:"aws_use_instance_role,omitempty"`
+	AwsUseInstanceRole bool     `json:"aws_use_instance_role"`
 }
 
 type BasicCredentials struct {
@@ -306,7 +306,7 @@ func (source *Source) AuthenticateToECR() bool {
 	}))
 
 	// Override mySession if aws_use_instance_role is set
-	if source.AwsUseInstanceRole == true {
+	if source.AwsUseInstanceRole {
 		mySession = session.Must(session.NewSession(&aws.Config{
 			Region: aws.String(source.AwsRegion)}))
 	}

--- a/types.go
+++ b/types.go
@@ -62,7 +62,7 @@ type AwsCredentials struct {
 	AWSECRRegistryId   string   `json:"aws_ecr_registry_id,omitempty"`
 	AwsRoleArn         string   `json:"aws_role_arn,omitempty"`
 	AwsRoleArns        []string `json:"aws_role_arns,omitempty"`
-	AwsUseInstanceRole bool     `json:"aws_use_instance_role"`
+	AwsUseInstanceRole bool     `json:"aws_use_instance_role,omitempty"`
 }
 
 type BasicCredentials struct {
@@ -306,7 +306,7 @@ func (source *Source) AuthenticateToECR() bool {
 	}))
 
 	// Override mySession if aws_use_instance_role is set
-	if source.AwsUseInstanceRole {
+	if source.AwsUseInstanceRole == true {
 		mySession = session.Must(session.NewSession(&aws.Config{
 			Region: aws.String(source.AwsRegion)}))
 	}

--- a/types_test.go
+++ b/types_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Source", func() {
 		json, err := json.Marshal(source)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(json).To(MatchJSON(`{"repository":"foo","insecure":false,"tag":"0"}`))
+		Expect(json).To(MatchJSON(`{"repository":"foo","insecure":false,"tag":"0", "aws_use_instance_role":false}`))
 	})
 
 	Describe("ecr", func() {


### PR DESCRIPTION
This is in relation to the bug discussed here: https://github.com/concourse/registry-image-resource/issues/277

The current default behaviour doesn't allow EC2 IAM Roles to be assumed directly, I have added an aws_use_instance_role flag which - when set to true alongside the instance name - ignores other cred settings when authenticating with ECR to allow the instance role to be assumed.