### PR TITLE
Fix infinite wait on stuck progress bars

### DIFF
--- a/commands/unpack.go
+++ b/commands/unpack.go
@@ -178,5 +178,7 @@ func extractLayer(dest string, layer v1.Layer, bar *mpb.Bar, chown bool) error {
 		return err
 	}
 
+	bar.SetTotal(bar.Current(), true)
+
 	return nil
 }


### PR DESCRIPTION
Ran into the same issue described here: https://github.com/concourse/registry-image-resource/issues/303

Unfortunately I found it to be nondeterministic. But I couldn't reproduce the issue with the described change, and I see that a similar fix has already been merged into the `oci-build-task`. 