### PR TITLE
Relax auth around ECR

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ differences:
     <br>
     <em><strong>Note:</strong> If using ecr you only need the repository name,
     not the full URI e.g. <code>alpine</code> not
-    <code>012345678910.dkr.ecr.us-east-1.amazonaws.com/alpine</code></em>
+    <code>012345678910.dkr.ecr.us-east-1.amazonaws.com/alpine</code>. ECR usage
+    is NOT automatically detected. You must set the <code>aws_region</code> to
+    tell the resource to automatically use ECR.</em>
     </td>
   </tr>
   <tr>

--- a/commands/check.go
+++ b/commands/check.go
@@ -49,7 +49,7 @@ func (c *Check) Execute() error {
 		return fmt.Errorf("invalid payload: %s", err)
 	}
 
-	if req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "" {
+	if req.Source.AwsRegion != "" {
 		if !req.Source.AuthenticateToECR() {
 			return fmt.Errorf("cannot authenticate with ECR")
 		}

--- a/commands/in.go
+++ b/commands/in.go
@@ -65,7 +65,7 @@ func (i *In) Execute() error {
 
 	dest := i.args[1]
 
-	if req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "" {
+	if req.Source.AwsRegion != "" {
 		if !req.Source.AuthenticateToECR() {
 			return fmt.Errorf("cannot authenticate with ECR")
 		}

--- a/commands/out.go
+++ b/commands/out.go
@@ -63,7 +63,7 @@ func (o *Out) Execute() error {
 
 	src := o.args[1]
 
-	if req.Source.AwsAccessKeyId != "" && req.Source.AwsSecretAccessKey != "" && req.Source.AwsRegion != "" {
+	if req.Source.AwsRegion != "" {
 		if !req.Source.AuthenticateToECR() {
 			return fmt.Errorf("cannot authenticate with ECR")
 		}

--- a/types.go
+++ b/types.go
@@ -307,10 +307,15 @@ func (source *Source) AuthenticateToECR() bool {
 		return false
 	}
 
-	mySession := session.Must(session.NewSession(&aws.Config{
-		Region:      aws.String(source.AwsRegion),
-		Credentials: credentials.NewStaticCredentials(source.AwsAccessKeyId, source.AwsSecretAccessKey, source.AwsSessionToken),
-	}))
+	awsConfig := aws.Config{
+		Region: aws.String(source.AwsRegion),
+	}
+
+	if source.AwsAccessKeyId != "" && source.AwsSecretAccessKey != "" && source.AwsSessionToken != "" {
+		awsConfig.Credentials = credentials.NewStaticCredentials(source.AwsAccessKeyId, source.AwsSecretAccessKey, source.AwsSessionToken)
+	}
+
+	mySession := session.Must(session.NewSession(&awsConfig))
 
 	// Note: This implementation gives precedence to `aws_role_arn` since it
 	// assumes that we've errored if both `aws_role_arn` and `aws_role_arns`

--- a/types.go
+++ b/types.go
@@ -311,7 +311,7 @@ func (source *Source) AuthenticateToECR() bool {
 		Region: aws.String(source.AwsRegion),
 	}
 
-	if source.AwsAccessKeyId != "" && source.AwsSecretAccessKey != "" && source.AwsSessionToken != "" {
+	if source.AwsAccessKeyId != "" && source.AwsSecretAccessKey != "" {
 		awsConfig.Credentials = credentials.NewStaticCredentials(source.AwsAccessKeyId, source.AwsSecretAccessKey, source.AwsSessionToken)
 	}
 


### PR DESCRIPTION
Fixes #277

Kudo's to @samed and his comment here: https://github.com/concourse/registry-image-resource/issues/277#issuecomment-960285967

Basically the same patch with an added conditional for optionally adding creds if they're present.

I've tested this on a Concourse worker running on AWS with an instance profile that has the relevant ECR permissions. `check`, `get`, and `put` steps all work.