### PR TITLE
Uid&Gid info lost for emptied directory while unpack image

### DIFF
--- a/commands/unpack.go
+++ b/commands/unpack.go
@@ -119,7 +119,7 @@ func extractLayer(dest string, layer v1.Layer, bar *mpb.Bar, chown bool) error {
 			if err := os.Mkdir(dir, fi.Mode()&os.ModePerm); err != nil {
 				return err
 			}
-			// Fix issue introduced by https://github.com/concourse/registry-image-resource/pull/284
+
 			if runtime.GOOS != "windows" && chown {
 				err = os.Lchown(dir, hdr.Uid, hdr.Gid)
 				if err != nil {

--- a/commands/unpack.go
+++ b/commands/unpack.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/concourse/go-archive/tarfs"
@@ -118,7 +119,13 @@ func extractLayer(dest string, layer v1.Layer, bar *mpb.Bar, chown bool) error {
 			if err := os.Mkdir(dir, fi.Mode()&os.ModePerm); err != nil {
 				return err
 			}
-
+			// Fix issue introduced by https://github.com/concourse/registry-image-resource/pull/284
+			if runtime.GOOS != "windows" && chown {
+				err = os.Lchown(dir, hdr.Uid, hdr.Gid)
+				if err != nil {
+					return err
+				}
+			}
 			continue
 		} else if strings.HasPrefix(base, whiteoutPrefix) {
 			// layer has marked a file as deleted

--- a/in_test.go
+++ b/in_test.go
@@ -229,6 +229,18 @@ var _ = Describe("In", func() {
 			stat, err = os.Stat(rootfsPath("top-dir-3", "nested-dir"))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stat.IsDir()).To(BeTrue())
+
+			stat, err = os.Stat(rootfsPath("top-dir-4"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stat.IsDir()).To(BeTrue())
+
+			if os.Geteuid() != 0 {
+				Skip("Must be run as root to validate file ownership")
+			}
+			sys, ok := stat.Sys().(*syscall.Stat_t)
+			Expect(ok).To(BeTrue())
+			Expect(sys.Uid).To(Equal(uint32(1000)))
+			Expect(sys.Gid).To(Equal(uint32(1000)))
 		})
 	})
 

--- a/testdata/whiteout/Dockerfile
+++ b/testdata/whiteout/Dockerfile
@@ -17,6 +17,7 @@ RUN touch top-dir-2/nested-dir-gone/nested-file-gone
 RUN rm -rf top-dir-2
 RUN mkdir -p top-dir-3/nested-dir-gone
 RUN rm -r top-dir-3 && mkdir -p top-dir-3/nested-dir
+RUN mkdir top-dir-4 && chown 1000:1000 top-dir-4
 
 # resulting file tree should be:
 # /top-dir-1/nested-file
@@ -24,3 +25,4 @@ RUN rm -r top-dir-3 && mkdir -p top-dir-3/nested-dir
 # /top-dir-1/nested-dir/file-recreated
 # /top-dir-1/nested-dir/file-then-dir
 # /top-dir-3/nested-dir
+# /top-dir-4


### PR DESCRIPTION
If a emptied directory created in Dockerfile, it will not `chown` to restore the origin uid&gid during unpack image. This was handled by `tarfs.ExtractEntry`
- https://github.com/vmware-archive/go-archive/blob/v1.0.1/tarfs/extract.go#L123-L128
- introduced since https://github.com/concourse/registry-image-resource/pull/284.


Signed-off-by: Ming Xu <mingx@vmware.com>