### PR TITLE
Add `labels.json` with image labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ The resource will produce the following files:
   For ECR images, this will include the registry the image was pulled from.
 * `./tag`: A file containing the tag from the version.
 * `./digest`: A file containing the digest from the version, e.g. `sha256:...`.
+* `./labels.json`: A file containing a JSON map of image labels, e.g. `{ "commit": "4e5c4ea" }`
 
 The remaining files depend on the configuration value for `format`:
 


### PR DESCRIPTION
This PR implements the suggestion from #295 to add the `labels.json` file.  The file is written by the `in` command in `map[string]string` format, and is compatible with `load_var`.

Both rootfs and OCI formats are supported.  However, the OCI format requires that the config file be parsed, which was not an existing error case.  One alternative I considered was returning an empty map, rather than raising the error.  Let me know what you think...

For a bit of background, I need this to extract a git revision label that was created by `oci-build-task`.  This allows later pipelines to update git tags, using just the `registry-image` input.