### PR TITLE
Add aws_account_id parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,15 @@ differences:
     </td>
   </tr>
   <tr>
+    <td><code>aws_account_id</code> <em>(Optional)</em></td>
+    <td>
+    The AWS Account ID that the image is located in. Useful if interacting with
+    images in another account. If omitted then the current AWS account ID will
+    be used. Be sure to wrap the account ID in quotes so it is parsed as a
+    string instead of a number.
+    </td>
+  </tr>
+  <tr>
     <td><code>platform</code> <em>(Optional)<br>(Experimental)</em></td>
     <td>
       <ul>

--- a/types.go
+++ b/types.go
@@ -64,6 +64,7 @@ type AwsCredentials struct {
 	AWSECRRegistryId   string   `json:"aws_ecr_registry_id,omitempty"`
 	AwsRoleArn         string   `json:"aws_role_arn,omitempty"`
 	AwsRoleArns        []string `json:"aws_role_arns,omitempty"`
+	AwsAccountId       string   `json:"aws_account_id,omitempty"`
 }
 
 type BasicCredentials struct {
@@ -426,7 +427,12 @@ func (source *Source) AuthenticateToECR() bool {
 
 	// Update username and repository
 	source.Username = "AWS"
-	source.Repository = strings.Join([]string{strings.TrimPrefix(*result.AuthorizationData[0].ProxyEndpoint, "https://"), source.Repository}, "/")
+
+	if source.AwsAccountId != "" {
+		source.Repository = fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", source.AwsAccountId, source.AwsRegion, source.Repository)
+	} else {
+		source.Repository = fmt.Sprintf("%s/%s", strings.TrimPrefix(*result.AuthorizationData[0].ProxyEndpoint, "https://"), source.Repository)
+	}
 
 	return true
 }


### PR DESCRIPTION
useful for when you need to interact with images stored in another account. Otherwise the current aws auth flow assumes it's coming from the current account.