### PR TITLE
Allow overriding Repository / Tag on Get

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ Fetches an image at the exact digest specified by the version.
     <td><code>repository</code> <em>(Optional)</em></td>
     <td>
       Override the repository defined in the <code>source</code> configuration.
-      Useful when dynamically passing a repo in a job.
+      Useful when dynamically passing a repo in a job. Not intended to be used with `trigger`.
     </td>
   </tr>
   <tr>
@@ -463,7 +463,7 @@ Fetches an image at the exact digest specified by the version.
     <td><code>tag</code> <em>(Optional)</em></td>
     <td>
       Override the tag defined in the <code>source</code>.
-      Useful when dynamically passing a tag in a job.
+      Useful when dynamically passing a tag in a job. Not intended to be used with `trigger`.
     </td>
   </tr>
 </tbody>

--- a/README.md
+++ b/README.md
@@ -446,6 +446,26 @@ Fetches an image at the exact digest specified by the version.
       needing to download the image you just uploaded.
     </td>
   </tr>
+  <tr>
+    <td><code>repository</code> <em>(Optional)</em></td>
+    <td>
+      Override the repository defined in the <code>source</code> configuration.
+      Useful when dynamically passing a repo in a job.
+    </td>
+  </tr>
+  <tr>
+    <td><code>insecure</code> <em>(Optional)<br>Default: false</em></td>
+    <td>
+      Allow insecure registry.
+    </td>
+  </tr>
+  <tr>
+    <td><code>tag</code> <em>(Optional)</em></td>
+    <td>
+      Override the tag defined in the <code>source</code>.
+      Useful when dynamically passing a tag in a job.
+    </td>
+  </tr>
 </tbody>
 </table>
 

--- a/commands/in.go
+++ b/commands/in.go
@@ -71,12 +71,24 @@ func (i *In) Execute() error {
 		}
 	}
 
-	repo, err := req.Source.NewRepository()
+	// override source if repository is passed in get param
+	repo := name.Repository{}
+	if req.Params.Repository != "" {
+		repo, err = req.Params.NewRepository()
+	} else {
+		repo, err = req.Source.NewRepository()
+	}
 	if err != nil {
 		return fmt.Errorf("failed to resolve repository: %w", err)
 	}
 
-	tag := repo.Tag(req.Version.Tag)
+	// override source if tag is passed in get param
+	tag := name.Tag{}
+	if req.Params.Tag != "" {
+		tag = repo.Tag(req.Params.Tag.String())
+	} else {
+		tag = repo.Tag(req.Version.Tag)
+	}
 
 	if !req.Params.SkipDownload {
 		mirrorSource, hasMirror, err := req.Source.Mirror()

--- a/types.go
+++ b/types.go
@@ -479,6 +479,9 @@ type MetadataField struct {
 type GetParams struct {
 	RawFormat    string `json:"format"`
 	SkipDownload bool   `json:"skip_download"`
+	Repository   string `json:"repository,omitempty"`
+	Insecure     bool   `json:"insecure"`
+	Tag          Tag    `json:"tag,omitempty"`
 }
 
 func (p GetParams) Format() string {
@@ -487,6 +490,18 @@ func (p GetParams) Format() string {
 	}
 
 	return p.RawFormat
+}
+
+func (p GetParams) NewRepository() (name.Repository, error) {
+	return name.NewRepository(p.Repository, p.RepositoryOptions()...)
+}
+
+func (p GetParams) RepositoryOptions() []name.Option {
+	var opts []name.Option
+	if p.Insecure {
+		opts = append(opts, name.Insecure)
+	}
+	return opts
 }
 
 type PutParams struct {


### PR DESCRIPTION
This is a very simplistic approach to a specific use-case:

We have various docker `base` images that we would like to pull in to build from.

We currently use the `registry-image-resource` to pull this `base` image in oci format to satisfy the `FROM` requirement in our Dockerfiles from a private  repository using `ARG`:

*Dockerfile*
```
ARG base_image=base
FROM ${base_image}

...
``` 

*Pipeline*
```yaml
resources:
- base
   type: registry-image
   source:
     aws_access_key_id: ((id))
     aws_secret_access_key: ((key)
     aws_region: ((region))
     repository: base-dotnet
     tag: 1.0.0

jobs:
  ...
  # we trigger the pipeline some other way

  - get: base
     params:
       format: oci

  - task: build
     privileged: true
     config:
       image_resource:
         type: registry-image
         source:
            repository: concourse/oci-build-task
       inputs:
          - name: base
       ...

```

We now would like to parallelize our builds of multiple docker images - we produce a json that contains metadata about each of docker images we want to build - including the base we want to use - this is what requires us to override the source configuration for `repository` and `tag`:

`metadata.json`
```json
[
  { 
    "service": "foo-api",
    "base_image": "foo-base",
    "base_tag": "1.0.0"
  },
  { 
    "service": "bar-api",
    "base_image": "bar-base",
    "base_tag": "2.0.0"
  }
]
```
*Pipeline*
```yaml
jobs:
  ...
  # we trigger the pipeline some other way

  - load_var: metadata
    file: metadata.json

  - do:
    - get: base
       params:
         format: oci
         repository: ((.:service.base_image))
         tag: ((.:service.base_tag))

    - task: build
       privileged: true
       config:
         image_resource:
           type: registry-image
           source:
              repository: concourse/oci-build-task
         inputs:
            - name: base
       ...

     across:
       - var: service
          max_in_fligh: all
          values: ((.:metadata))

```

Now clearly this will have implications if we wanted to use the `base`/`registry-image-resource` to trigger.

Any thoughts around a better way to achieve what we want?
cc @taylorsilva 

