### PR TITLE
feat: explicitly set USER root

### DIFF
--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -18,6 +18,7 @@ RUN set -e; for pkg in $(go list ./...); do \
 	done
 
 FROM ${base_image} AS resource
+USER root
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt upgrade -y -o Dpkg::Options::="--force-confdef"
 RUN apt update \


### PR DESCRIPTION
- paketo doesn't have a default user root