### PR TITLE
feat: support arbitrary prerelease strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ differences:
   <tr>
     <td><code>pre_release_prefixes</code> <em>(Optional)</em></td>
     <td>
-    Opt in to additional pre-release prefixes (e.g. `build.3`)
+    An array of strings, where each string is an additional pre-release prefix that should be found (e.g. `build.3`). `pre_releases` must be set to `true`.
     </td>
   </tr>
   <tr>

--- a/README.md
+++ b/README.md
@@ -134,8 +134,14 @@ differences:
     Note however that variants and pre-releases both use the same syntax:
     `1.2.3-alpine` is technically also valid syntax for a Semver prerelease. For
     this reason, the resource will only consider prerelease data starting with
-    `alpha`, `beta`, or `rc` as a proper prerelease, treating anything else as
-    a variant.
+    `alpha`, `beta`, or `rc` as a proper prerelease, or values provided by
+    `pre_release_prefixes`, treating anything else as a variant.
+    </td>
+  </tr>
+  <tr>
+    <td><code>pre_release_prefixes</code> <em>(Optional)</em></td>
+    <td>
+    Opt in to additional pre-release prefixes (e.g. `build.3`)
     </td>
   </tr>
   <tr>

--- a/check_test.go
+++ b/check_test.go
@@ -1095,6 +1095,30 @@ var _ = DescribeTable("tracking semver tags",
 			},
 		},
 	),
+	Entry("prerelease prefixes opted in",
+		SemverOrRegexTagCheckExample{
+			Tags: []testTag{
+				{Tag: "1.0.0-alpha.1", ImageName: "random-0"},
+				{Tag: "1.0.0", ImageName: "random-1"},
+				{Tag: "1.2.1-beta.1", ImageName: "random-2"},
+				{Tag: "1.2.1", ImageName: "random-3"},
+				{Tag: "2.0.0-rc.1", ImageName: "random-4"},
+				{Tag: "2.0.0", ImageName: "random-5"},
+				{Tag: "2.0.0-build.1", ImageName: "random-6"},
+			},
+			PreReleases:        true,
+			PreReleasePrefixes: []string{"build"},
+			Versions: []string{
+				"1.0.0-alpha.1",
+				"1.0.0",
+				"1.2.1-beta.1",
+				"1.2.1",
+				"2.0.0-build.1",
+				"2.0.0-rc.1",
+				"2.0.0",
+			},
+		},
+	),
 	Entry("prereleases do not include 'variants'",
 		SemverOrRegexTagCheckExample{
 			Tags: []testTag{
@@ -1474,6 +1498,34 @@ var _ = DescribeTable("tracking semver tags",
 			},
 		},
 	),
+	Entry("opting in to prereleases allows additional '-' suffixes before variant",
+		SemverOrRegexTagCheckExample{
+			Tags: []testTag{
+				{Tag: "1.0.0-build-foo", ImageName: "random-1"},
+				{Tag: "1.0.0-rc.1-foo", ImageName: "random-2"},
+				{Tag: "1.0.0-alpha.1-foo", ImageName: "random-3"},
+				{Tag: "1.0.0-beta.1-foo", ImageName: "random-4"},
+				{Tag: "1.0.0-bar-foo", ImageName: "random-5"},
+				{Tag: "1.0.0-rc.1-bar-foo", ImageName: "random-6"},
+				{Tag: "1.0.0-alpha.1-bar-foo", ImageName: "random-7"},
+				{Tag: "1.0.0-beta.1-bar-foo", ImageName: "random-8"},
+			},
+
+			Variant:            "foo",
+			PreReleases:        true,
+			PreReleasePrefixes: []string{"build"},
+
+			Versions: []string{
+				"1.0.0-alpha.1-foo",
+				"1.0.0-alpha.1-bar-foo",
+				"1.0.0-beta.1-foo",
+				"1.0.0-beta.1-bar-foo",
+				"1.0.0-build-foo",
+				"1.0.0-rc.1-foo",
+				"1.0.0-rc.1-bar-foo",
+			},
+		},
+	),
 	Entry("tries mirror and falls back on original repository",
 		SemverOrRegexTagCheckExample{
 			Tags: []testTag{
@@ -1530,8 +1582,9 @@ type SemverOrRegexTagCheckExample struct {
 	Tags       []testTag
 	TagsToTime map[string]time.Time
 
-	PreReleases bool
-	Variant     string
+	PreReleases        bool
+	PreReleasePrefixes []string
+	Variant            string
 
 	Regex         string
 	CreatedAtSort bool
@@ -1570,12 +1623,13 @@ func (example SemverOrRegexTagCheckExample) Run() {
 
 	req := resource.CheckRequest{
 		Source: resource.Source{
-			Repository:       repo.Name(),
-			PreReleases:      example.PreReleases,
-			Variant:          example.Variant,
-			SemverConstraint: example.SemverConstraint,
-			Regex:            example.Regex,
-			CreatedAtSort:    example.CreatedAtSort,
+			Repository:         repo.Name(),
+			PreReleases:        example.PreReleases,
+			PreReleasePrefixes: example.PreReleasePrefixes,
+			Variant:            example.Variant,
+			SemverConstraint:   example.SemverConstraint,
+			Regex:              example.Regex,
+			CreatedAtSort:      example.CreatedAtSort,
 		},
 	}
 

--- a/check_test.go
+++ b/check_test.go
@@ -1098,13 +1098,34 @@ var _ = DescribeTable("tracking semver tags",
 	Entry("prerelease prefixes opted in",
 		SemverOrRegexTagCheckExample{
 			Tags: []testTag{
-				{Tag: "1.0.0-alpha.1", ImageName: "random-0"},
-				{Tag: "1.0.0", ImageName: "random-1"},
-				{Tag: "1.2.1-beta.1", ImageName: "random-2"},
-				{Tag: "1.2.1", ImageName: "random-3"},
-				{Tag: "2.0.0-rc.1", ImageName: "random-4"},
-				{Tag: "2.0.0", ImageName: "random-5"},
-				{Tag: "2.0.0-build.1", ImageName: "random-6"},
+				{
+					Tag:       "1.0.0-alpha.1",
+					ImageName: "random-0",
+				},
+				{
+					Tag:       "1.0.0",
+					ImageName: "random-1",
+				},
+				{
+					Tag:       "1.2.1-beta.1",
+					ImageName: "random-2",
+				},
+				{
+					Tag:       "1.2.1",
+					ImageName: "random-3",
+				},
+				{
+					Tag:       "2.0.0-rc.1",
+					ImageName: "random-4",
+				},
+				{
+					Tag:       "2.0.0",
+					ImageName: "random-5",
+				},
+				{
+					Tag:       "2.0.0-build.1",
+					ImageName: "random-6",
+				},
 			},
 			PreReleases:        true,
 			PreReleasePrefixes: []string{"build"},
@@ -1501,14 +1522,38 @@ var _ = DescribeTable("tracking semver tags",
 	Entry("opting in to prereleases allows additional '-' suffixes before variant",
 		SemverOrRegexTagCheckExample{
 			Tags: []testTag{
-				{Tag: "1.0.0-build-foo", ImageName: "random-1"},
-				{Tag: "1.0.0-rc.1-foo", ImageName: "random-2"},
-				{Tag: "1.0.0-alpha.1-foo", ImageName: "random-3"},
-				{Tag: "1.0.0-beta.1-foo", ImageName: "random-4"},
-				{Tag: "1.0.0-bar-foo", ImageName: "random-5"},
-				{Tag: "1.0.0-rc.1-bar-foo", ImageName: "random-6"},
-				{Tag: "1.0.0-alpha.1-bar-foo", ImageName: "random-7"},
-				{Tag: "1.0.0-beta.1-bar-foo", ImageName: "random-8"},
+				{
+					Tag:       "1.0.0-build-foo",
+					ImageName: "random-1",
+				},
+				{
+					Tag:       "1.0.0-rc.1-foo",
+					ImageName: "random-2",
+				},
+				{
+					Tag:       "1.0.0-alpha.1-foo",
+					ImageName: "random-3",
+				},
+				{
+					Tag:       "1.0.0-beta.1-foo",
+					ImageName: "random-4",
+				},
+				{
+					Tag:       "1.0.0-bar-foo",
+					ImageName: "random-5",
+				},
+				{
+					Tag:       "1.0.0-rc.1-bar-foo",
+					ImageName: "random-6",
+				},
+				{
+					Tag:       "1.0.0-alpha.1-bar-foo",
+					ImageName: "random-7",
+				},
+				{
+					Tag:       "1.0.0-beta.1-bar-foo",
+					ImageName: "random-8",
+				},
 			},
 
 			Variant:            "foo",

--- a/commands/check.go
+++ b/commands/check.go
@@ -173,14 +173,23 @@ func checkRepository(repo name.Repository, source resource.Source, from *resourc
 					continue
 				}
 
-				// contains additional variant
-				if strings.Contains(pre, "-") {
-					continue
+				preReleasePrefixes := []string{"alpha", "beta", "rc"}
+				if source.PreReleasePrefixes != nil && len(source.PreReleasePrefixes) > 0 {
+					preReleasePrefixes = append(preReleasePrefixes, source.PreReleasePrefixes...)
+				} else {
+					if strings.Contains(pre, "-") {
+						// contains additional variant
+						continue
+					}
 				}
 
-				if !strings.HasPrefix(pre, "alpha") &&
-					!strings.HasPrefix(pre, "beta") &&
-					!strings.HasPrefix(pre, "rc") {
+				match := false
+				for _, prefix := range preReleasePrefixes {
+					if strings.HasPrefix(pre, prefix) {
+						match = true
+					}
+				}
+				if ! match {
 					// additional variant, not a prerelease segment
 					continue
 				}

--- a/commands/check.go
+++ b/commands/check.go
@@ -189,7 +189,7 @@ func checkRepository(repo name.Repository, source resource.Source, from *resourc
 						match = true
 					}
 				}
-				if ! match {
+				if !match {
 					// additional variant, not a prerelease segment
 					continue
 				}

--- a/types.go
+++ b/types.go
@@ -88,8 +88,9 @@ type Source struct {
 
 	Insecure bool `json:"insecure"`
 
-	PreReleases bool   `json:"pre_releases,omitempty"`
-	Variant     string `json:"variant,omitempty"`
+	PreReleases bool `json:"pre_releases,omitempty"`
+	PreReleasePrefixes []string `json:"pre_release_prefixes,omitempty"`
+	Variant string `json:"variant,omitempty"`
 
 	SemverConstraint string `json:"semver_constraint,omitempty"`
 

--- a/types.go
+++ b/types.go
@@ -88,9 +88,9 @@ type Source struct {
 
 	Insecure bool `json:"insecure"`
 
-	PreReleases bool `json:"pre_releases,omitempty"`
+	PreReleases        bool     `json:"pre_releases,omitempty"`
 	PreReleasePrefixes []string `json:"pre_release_prefixes,omitempty"`
-	Variant string `json:"variant,omitempty"`
+	Variant            string   `json:"variant,omitempty"`
 
 	SemverConstraint string `json:"semver_constraint,omitempty"`
 


### PR DESCRIPTION
The current implementation assumes the prerelease portion of a semver tag is alpha/beta/rc optionally followed by a variant, with no other `-` characters. This MR adds a new source param to broaden support for arbitrary semver tags while maintaining backwards compatibility:

`source.pre_release_prefixes` lets the user append to the default prefixes of alpha/beta/rc (e.g. "dev" or "build")without otherwise changing the current pre_releases behaviour. Setting pre_release_prefixes skips the "pre-release contains `-`" check.

fix https://github.com/concourse/registry-image-resource/issues/307