### PR TITLE
refactor how we create additional tags

### DIFF
--- a/commands/out.go
+++ b/commands/out.go
@@ -124,12 +124,7 @@ func (o *Out) Execute() error {
 	}
 
 	for _, tagName := range additionalTags {
-		tag, err := name.NewTag(fmt.Sprintf("%s:%s", req.Source.Repository, tagName))
-		if err != nil {
-			return fmt.Errorf("could not resolve repository/tag reference: %w", err)
-		}
-
-		tagsToPush = append(tagsToPush, tag)
+		tagsToPush = append(tagsToPush, repo.Tag(tagName))
 	}
 
 	if len(tagsToPush) == 0 {


### PR DESCRIPTION
Using `repo.Tag()` is how we do it everywhere else in the code. I see no reason to do this any differently here.

Found this opportunity while looking at #355