### PR TITLE
Add support for ECR public repository (public.ecr.aws)

### DIFF
--- a/commands/check.go
+++ b/commands/check.go
@@ -51,7 +51,8 @@ func (c *Check) Execute() error {
 		return fmt.Errorf("invalid payload: %s", err)
 	}
 
-	if req.Source.AwsRegion != "" {
+	isPublicECR := strings.Contains(req.Source.Repository, "public.ecr.aws")
+	if !isPublicECR && req.Source.AwsRegion != "" {
 		if !req.Source.AuthenticateToECR() {
 			return fmt.Errorf("cannot authenticate with ECR")
 		}

--- a/commands/in.go
+++ b/commands/in.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	resource "github.com/concourse/registry-image-resource"
 	"github.com/fatih/color"
@@ -64,7 +65,8 @@ func (i *In) Execute() error {
 
 	dest := i.args[1]
 
-	if req.Source.AwsRegion != "" {
+	isPublicECR := strings.Contains(req.Source.Repository, "public.ecr.aws")
+	if !isPublicECR && req.Source.AwsRegion != "" {
 		if !req.Source.AuthenticateToECR() {
 			return fmt.Errorf("cannot authenticate with ECR")
 		}


### PR DESCRIPTION
This commit adds support for Amazon ECR Public repositories to the registry-image-resource. Key changes include:

- Skip authentication for public ECR repositories in check and in operations since they are publicly accessible
- For out operations on public ECR, use AWS credentials but skip ECR token retrieval

The implementation detects public ECR repositories by looking for "public.ecr.aws" in the repository string and applies different authentication logic based on the operation type.

This enables Concourse pipelines to both pull from public ECR repositories without authentication and push to public ECR repositories with proper AWS credentials.

STILL TO BE TESTED