### PR TITLE
Unwrap nested Image Index's when pushing

### DIFF
--- a/commands/in.go
+++ b/commands/in.go
@@ -134,6 +134,11 @@ func downloadWithRetry(tag name.Tag, source resource.Source, params resource.Get
 			return err
 		}
 
+		// In case anyone else wonders why we don't show a progress bar for
+		// downloads, it's because go-containerregistry doesn't expose anything
+		// for us to show the download progress:
+		// https://github.com/google/go-containerregistry/issues/670
+		// Maybe we should switch to using oras-go?
 		switch params.Format() {
 		case "oci-layout":
 			return saveOciLayout(repo, version, dest, opts)

--- a/commands/out.go
+++ b/commands/out.go
@@ -140,7 +140,7 @@ func (o *Out) Execute() error {
 		return fmt.Errorf("no files match glob '%s'", req.Params.Image)
 	}
 	if len(matches) > 1 {
-		return fmt.Errorf("too many files match glob '%s': %v", req.Params.Image, matches)
+		return fmt.Errorf("too many files/directories match glob '%s': %v", req.Params.Image, matches)
 	}
 
 	img, err := loadImage(matches[0])

--- a/commands/rootfs.go
+++ b/commands/rootfs.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"archive/tar"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -32,7 +33,8 @@ func unpackImage(dest string, img v1.Image, debug bool, out io.Writer) error {
 		out = io.Discard
 	}
 
-	progress := mpb.New(mpb.WithOutput(out))
+	fmt.Fprintln(out, "Extracting image")
+	progress := mpb.New(mpb.WithOutput(out), mpb.WithAutoRefresh())
 
 	bars := make([]*mpb.Bar, len(layers))
 

--- a/commands/unpack.go
+++ b/commands/unpack.go
@@ -13,8 +13,8 @@ import (
 	"github.com/fatih/color"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/sirupsen/logrus"
-	"github.com/vbauerster/mpb"
-	"github.com/vbauerster/mpb/decor"
+	"github.com/vbauerster/mpb/v8"
+	"github.com/vbauerster/mpb/v8/decor"
 )
 
 const whiteoutPrefix = ".wh."

--- a/go.mod
+++ b/go.mod
@@ -19,11 +19,12 @@ require (
 	github.com/onsi/gomega v1.36.2
 	github.com/simonshyu/notary-gcr v0.0.0-20220601090547-d99a631aa58b
 	github.com/sirupsen/logrus v1.9.3
-	github.com/vbauerster/mpb v3.4.0+incompatible
+	github.com/vbauerster/mpb/v8 v8.9.3
 )
 
 require (
 	github.com/VividCortex/ewma v1.2.0 // indirect
+	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34 // indirect
@@ -48,12 +49,14 @@ require (
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/miekg/pkcs11 v1.1.1 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/onsi/ginkgo v1.16.4 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/theupdateframework/notary v0.7.0 // indirect
 	github.com/vbatts/tar-split v0.12.1 // indirect
 	golang.org/x/crypto v0.36.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -668,6 +670,8 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
+github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/go-sqlite3 v1.6.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
@@ -829,6 +833,9 @@ github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3x
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -921,8 +928,8 @@ github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/vbatts/tar-split v0.11.2/go.mod h1:vV3ZuO2yWSVsz+pfFzDG/upWH1JhjOiEaWq6kXyQ3VI=
 github.com/vbatts/tar-split v0.12.1 h1:CqKoORW7BUWBe7UL/iqTVvkTBOF8UvOMKOIZykxnnbo=
 github.com/vbatts/tar-split v0.12.1/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
-github.com/vbauerster/mpb v3.4.0+incompatible h1:mfiiYw87ARaeRW6x5gWwYRUawxaW1tLAD8IceomUCNw=
-github.com/vbauerster/mpb v3.4.0+incompatible/go.mod h1:zAHG26FUhVKETRu+MWqYXcI70POlC6N8up9p1dID7SU=
+github.com/vbauerster/mpb/v8 v8.9.3 h1:PnMeF+sMvYv9u23l6DO6Q3+Mdj408mjLRXIzmUmU2Z8=
+github.com/vbauerster/mpb/v8 v8.9.3/go.mod h1:hxS8Hz4C6ijnppDSIX6LjG8FYJSoPo9iIOcE53Zik0c=
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=

--- a/out_test.go
+++ b/out_test.go
@@ -232,7 +232,7 @@ var _ = Describe("Out", func() {
 
 				It("exits non-zero and returns an error", func() {
 					Expect(actualErr).To(HaveOccurred())
-					Expect(actualErrOutput).To(ContainSubstring("too many files match glob"))
+					Expect(actualErrOutput).To(ContainSubstring("too many files/directories match glob"))
 				})
 			})
 

--- a/types.go
+++ b/types.go
@@ -506,7 +506,7 @@ func (p GetParams) Format() string {
 }
 
 type PutParams struct {
-	// Path to an OCI image tarball to push.
+	// Path to an OCI image tarball or directory in OCI-layout format to push.
 	Image string `json:"image"`
 
 	// Version number to publish. If a variant is configured, it will be


### PR DESCRIPTION
I found that when pushing a multi-arch image to Docker Hub, I wouldn't
see which platforms the image supported like I would when pushing a
multi-arch image with the Docker CLI.

After digging into the OCI-layout I found out that buildkit, when
exporting the image to disk in oci-layout format, wraps the image index
in another image index. I'm not sure why it does that; haven't bothered
to dig into it in the buildkit code. It seems buildkit only does this
when writing the image to disk. My guess is it does it for legacy reason.
The ImageIndex wrapped looks like this:

```json
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.index.v1+json",
      "digest": "sha256:55bf56746c776b4cc84498657dbaeeb33b247956dc08c6763b6ce2a7b53d2da2",
      "size": 647,
      "annotations": {
        "org.opencontainers.image.created": "2025-04-22T21:01:52Z"
      }
    }
  ]
}
```

The problem is that when you push this wrapped ImageIndex, image
registries like Docker Hub don't know or display the platforms the image
supports.

When pushing the image using `docker push` or using the oras CLI to
push the local oci-layout image I made from buildkit, I found they both
pushed the nested image index instead of the parent. The nested image
index looks like this btw:

```json
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:4fce054b00b7a0363412c153bfec7e2093fd5dbd3a64256f21c1843bbc35f98e",
      "size": 669,
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:74b79ed32d2ba388471560515c3be5980c89d5143ae760a7b9a005e2b925907c",
      "size": 668,
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    }
  ]
}
```

This PR has the registry image unwrap all nested image indexes until
it gets an ImageIndex that contains one or more manifests that are not
another ImageIndex.

I've tested this and pushing multi-arch images with the registry-image
now correctly displays the platforms that were pushed. When mirroring
images, the original digests are still preserved as well.

I also did a little refactoring of the image pulling code. It got a bit hairy with the PR that added the oci-layout.

I also tried to see if it was possible to add progress bars while downloading the image. I found out that this is not supported by go-containerregistry: https://github.com/google/go-containerregistry/issues/670
The progress bars one sees when downloading in `rootfs` format is actually the progress of extracting the layers to disk. I've made the clear in the output now.

I think oras-go supports this since their CLI's show progress bars like docker: https://github.com/oras-project/oras-go
Switching to that would be a big overhaul though. It might be nicer to work with oras-go instead though.