### PR TITLE
Update description of image param format for put step in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,7 +565,8 @@ Tags may be specified in multiple ways:
   <tr>
     <td><code>image</code> <em>(Required)</em></td>
     <td>
-    Can be the path to the <code>oci</code> image tarball (e.g. <code>my-image/image.tar</code>)
+    Can be the path to the <code>docker</code> image tarball (e.g. <code>my-image/image.tar</code>)
+    or the path to the <code>oci</code> image tarball (e.g. <code>my-image/image</code>)
     or the path to an <a href="https://github.com/opencontainers/image-spec/blob/main/image-layout.md">OCI image layout</a> (e.g. <code>my-image/oci</code>).
     Expanded with <a href="https://golang.org/pkg/path/filepath/#Glob"><code>filepath.Glob</code></a>
     </td>


### PR DESCRIPTION
This PR adds instruction how to set `image` param in a put step when use `oci` image tarball. Additionaly for #368 #49
