### PR TITLE
Allow get steps to specify the platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ differences:
     </td>
   </tr>
   <tr>
-    <td><code>platform</code> <em>(Optional)<br>(Experimental)</em></td>
+    <td><code>platform</code> <em>(Optional)</em></td>
     <td>
       <ul>
         <li>
@@ -472,6 +472,23 @@ Fetches an image at the exact digest specified by the version.
   <tr>
     <td><code>format</code> <em>(Optional)<br>Default: <code>rootfs</code></em></td>
     <td>The format to fetch the image as. Accepted values are: <code>rootfs</code>, <code>oci</code>, <code>oci-layout</code></td>
+  </tr>
+  <tr>
+    <td><code>platform</code> <em>(Optional)</em></td>
+    <td>
+        <ul>
+            <li>
+            <code>architecture</code> <em>(Optional)</em>:
+            Architecture the image is built for (e.g. `amd64`, `arm64/v8`). If not
+            specified, will default to https://pkg.go.dev/runtime#GOARCH.
+            </li>
+            <li>
+            <code>os</code> <em>(Optional)</em>:
+            OS the image is built for (e.g. `linux`, `darwin`, `windows`). If not
+            specified, will default to https://pkg.go.dev/runtime#GOOS.
+            </li>
+        </ul>
+    </td>
   </tr>
   <tr>
     <td><code>skip_download</code> <em>(Optional)<br>Default: false</em></td>

--- a/commands/check.go
+++ b/commands/check.go
@@ -99,6 +99,12 @@ func check(source resource.Source, from *resource.Version) (resource.CheckRespon
 		return resource.CheckResponse{}, err
 	}
 
+	platform := source.Platform(nil)
+	opts = append(opts, remote.WithPlatform(v1.Platform{
+		Architecture: platform.Architecture,
+		OS:           platform.OS,
+	}))
+
 	if source.Tag != "" {
 		return checkTag(repo.Tag(source.Tag.String()), from, opts...)
 	} else if source.Regex != "" {

--- a/commands/in.go
+++ b/commands/in.go
@@ -134,6 +134,12 @@ func downloadWithRetry(tag name.Tag, source resource.Source, params resource.Get
 			return err
 		}
 
+		platform := source.Platform(params.RawPlatform)
+		opts = append(opts, remote.WithPlatform(v1.Platform{
+			Architecture: platform.Architecture,
+			OS:           platform.OS,
+		}))
+
 		// In case anyone else wonders why we don't show a progress bar for
 		// downloads, it's because go-containerregistry doesn't expose anything
 		// for us to show the download progress:

--- a/commands/out.go
+++ b/commands/out.go
@@ -304,6 +304,12 @@ func aliasesToBump(req resource.OutRequest, repo name.Repository, ver *semver.Ve
 		return nil, err
 	}
 
+	platform := req.Source.Platform(nil)
+	opts = append(opts, remote.WithPlatform(v1.Platform{
+		Architecture: platform.Architecture,
+		OS:           platform.OS,
+	}))
+
 	versions, err := remote.List(repo, opts...)
 	if err != nil && !isNewImage(err) {
 		return nil, fmt.Errorf("list repository tags: %w", err)

--- a/types_test.go
+++ b/types_test.go
@@ -48,20 +48,30 @@ var _ = Describe("Source", func() {
 	})
 
 	Describe("platform", func() {
-		It("should set platform to default if not specified", func() {
+		It("should set platform when specified in source", func() {
 			source := resource.Source{
 				RawPlatform: &resource.PlatformField{OS: "some-os", Architecture: "some-arch"},
 			}
 
-			platform := source.Platform()
+			platform := source.Platform(nil)
 			Expect(platform.Architecture).To(Equal("some-arch"))
 			Expect(platform.OS).To(Equal("some-os"))
+		})
+
+		It("should set platform when specified with step override", func() {
+			source := resource.Source{
+				RawPlatform: &resource.PlatformField{OS: "some-os", Architecture: "some-arch"},
+			}
+
+			platform := source.Platform(&resource.PlatformField{OS: "step-os", Architecture: "step-arch"})
+			Expect(platform.Architecture).To(Equal("step-arch"))
+			Expect(platform.OS).To(Equal("step-os"))
 		})
 
 		It("should set platform to default if not specified", func() {
 			var source resource.Source
 
-			platform := source.Platform()
+			platform := source.Platform(nil)
 			Expect(platform.Architecture).To(Equal(runtime.GOARCH))
 			Expect(platform.OS).To(Equal(runtime.GOOS))
 		})


### PR DESCRIPTION
Motivation for this is so we can pull multi-arch images down into rootfs format, which we need for when we build Concourse's final deployment package. Bit of a chicken/egg situation going on here with getting multi-arch images built 🙃 