### PR TITLE
Capture image ENTRYPOINT and CMD values in rootfs format

### DIFF
--- a/commands/in.go
+++ b/commands/in.go
@@ -18,8 +18,10 @@ import (
 )
 
 type ImageMetadata struct {
-	Env  []string `json:"env"`
-	User string   `json:"user"`
+	Cmd        []string `json:"cmd"`
+	EntryPoint []string `json:"entrypoint"`
+	Env        []string `json:"env"`
+	User       string   `json:"user"`
 }
 
 type In struct {
@@ -255,13 +257,11 @@ func rootfsFormat(dest string, image v1.Image, debug bool, stderr io.Writer) err
 		return fmt.Errorf("create image metadata: %w", err)
 	}
 
-	env := cfg.Config.Env
-
-	user := cfg.Config.User
-
 	err = json.NewEncoder(meta).Encode(ImageMetadata{
-		Env:  env,
-		User: user,
+		Env:        cfg.Config.Env,
+		User:       cfg.Config.User,
+		EntryPoint: cfg.Config.Entrypoint,
+		Cmd:        cfg.Config.Cmd,
 	})
 	if err != nil {
 		return fmt.Errorf("write image metadata: %w", err)

--- a/in_test.go
+++ b/in_test.go
@@ -114,6 +114,39 @@ var _ = Describe("In", func() {
 		})
 	})
 
+	Describe("image entrypoint and cmd", func() {
+		BeforeEach(func() {
+			req.Source.Repository = "concourse/test-image-entrypoint"
+			req.Version = resource.Version{
+				Tag:    "latest",
+				Digest: latestDigest(req.Source.Repository),
+			}
+		})
+
+		It("captures the entrypoint and cmd", func() {
+			Expect(actualErr).ToNot(HaveOccurred())
+
+			var meta struct {
+				Cmd        []string `json:"cmd"`
+				EntryPoint []string `json:"entrypoint"`
+			}
+
+			md, err := os.Open(filepath.Join(destDir, "metadata.json"))
+			Expect(err).ToNot(HaveOccurred())
+
+			defer md.Close()
+
+			json.NewDecoder(md).Decode(&meta)
+			Expect(meta.EntryPoint).To(Equal([]string{
+				"/bin/sh",
+			}))
+			Expect(meta.Cmd).To(Equal([]string{
+				"-c",
+				"echo hello world",
+			}))
+		})
+	})
+
 	Describe("response metadata", func() {
 		BeforeEach(func() {
 			req.Source.Repository = "concourse/test-image-metadata"

--- a/testdata/entrypoint/Dockerfile
+++ b/testdata/entrypoint/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine
+ENTRYPOINT [ "/bin/sh" ]
+CMD [ "-c", "echo hello world" ]


### PR DESCRIPTION
When exporting an image into `rootfs` format, include `entrypoint` and `cmd` from the OCI image, if present, into the `metadata.json` file that sits at the same level as the `rootfs/` directory.