### PR TITLE
Retry on common transient errors

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -2,16 +2,19 @@ package resource
 
 import (
 	"errors"
+	"io"
 	"net/http"
 	"os"
+	"syscall"
 	"time"
 
 	"github.com/cenkalti/backoff"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/net/http2"
 )
 
-func RetryOnRateLimit(op func() error) error {
+func RetryOnTransientError(op func() error) error {
 	bo := backoff.NewExponentialBackOff()
 	if os.Getenv("TEST") == "true" {
 		bo.InitialInterval = 5 * time.Millisecond
@@ -34,8 +37,26 @@ func RetryOnRateLimit(op func() error) error {
 			}
 		}
 
+		if isTransientError(err) {
+			return err
+		}
+
 		return backoff.Permanent(err)
 	}, bo, func(err error, dur time.Duration) {
-		logrus.Warnf("too many requests; retrying in %s", dur)
+		logrus.Warnf("transient error: %s; retrying in %s", err, dur)
 	})
+}
+
+func isTransientError(err error) bool {
+	var streamErr http2.StreamError
+	if errors.As(err, &streamErr) {
+		return true
+	}
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	if errors.Is(err, syscall.ECONNRESET) {
+		return true
+	}
+	return false
 }

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -1,0 +1,118 @@
+package resource_test
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"syscall"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"golang.org/x/net/http2"
+
+	resource "github.com/concourse/registry-image-resource"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+)
+
+var _ = Describe("Transient Error Handling", func() {
+
+	Describe("isTransientError", func() {
+		DescribeTable("identifies transient errors",
+			func(err error, expected bool) {
+				Expect(resource.IsTransientError(err)).To(Equal(expected))
+			},
+			Entry("http2 StreamError",
+				http2.StreamError{StreamID: 1, Code: http2.ErrCodeInternal},
+				true,
+			),
+			Entry("wrapped http2 StreamError",
+				fmt.Errorf("extract image: %w", http2.StreamError{StreamID: 67, Code: http2.ErrCodeInternal}),
+				true,
+			),
+			Entry("io.ErrUnexpectedEOF",
+				io.ErrUnexpectedEOF,
+				true,
+			),
+			Entry("wrapped io.ErrUnexpectedEOF",
+				fmt.Errorf("read body: %w", io.ErrUnexpectedEOF),
+				true,
+			),
+			Entry("ECONNRESET",
+				os.NewSyscallError("read", syscall.ECONNRESET),
+				true,
+			),
+			Entry("wrapped ECONNRESET",
+				fmt.Errorf("download layer: %w", os.NewSyscallError("read", syscall.ECONNRESET)),
+				true,
+			),
+			Entry("regular io.EOF",
+				io.EOF,
+				false,
+			),
+			Entry("generic error",
+				errors.New("something went wrong"),
+				false,
+			),
+			Entry("transport error 429 is not transient",
+				&transport.Error{StatusCode: http.StatusTooManyRequests},
+				false,
+			),
+		)
+	})
+
+	Describe("RetryOnTransientError", func() {
+		BeforeEach(func() {
+			// Makes the RetryOnTransientError() have an interval of 5ms instead of 5s
+			os.Setenv("TEST", "true")
+		})
+
+		It("succeeds on first try without retrying", func() {
+			calls := 0
+			err := resource.RetryOnTransientError(func() error {
+				calls++
+				return nil
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(calls).To(Equal(1))
+		})
+
+		It("retries on transient error and succeeds", func() {
+			calls := 0
+			err := resource.RetryOnTransientError(func() error {
+				calls++
+				if calls == 1 {
+					return fmt.Errorf("extract image: %w", http2.StreamError{StreamID: 67, Code: http2.ErrCodeInternal})
+				}
+				return nil
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(calls).To(Equal(2))
+		})
+
+		It("retries on rate limit and succeeds", func() {
+			calls := 0
+			err := resource.RetryOnTransientError(func() error {
+				calls++
+				if calls == 1 {
+					return &transport.Error{StatusCode: http.StatusTooManyRequests}
+				}
+				return nil
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(calls).To(Equal(2))
+		})
+
+		It("does not retry permanent errors", func() {
+			calls := 0
+			err := resource.RetryOnTransientError(func() error {
+				calls++
+				return errors.New("permanent failure")
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("permanent failure"))
+			Expect(calls).To(Equal(1))
+		})
+	})
+})

--- a/commands/in.go
+++ b/commands/in.go
@@ -136,7 +136,7 @@ func downloadWithRetry(tag name.Tag, source resource.Source, params resource.Get
 		return fmt.Errorf("resolve repository name: %w", err)
 	}
 
-	return resource.RetryOnRateLimit(func() error {
+	return resource.RetryOnTransientError(func() error {
 		opts, err := source.AuthOptions(repo, []string{transport.PullScope})
 		if err != nil {
 			return err

--- a/commands/out.go
+++ b/commands/out.go
@@ -168,14 +168,14 @@ func (o *Out) Execute() error {
 	}
 
 	opts := req.Source.NewOptions()
-	err = resource.RetryOnRateLimit(func() error {
+	err = resource.RetryOnTransientError(func() error {
 		return req.Source.SetOptions(&opts)
 	})
 	if err != nil {
 		return fmt.Errorf("failed to set repo/auth options: %w", err)
 	}
 
-	err = resource.RetryOnRateLimit(func() error {
+	err = resource.RetryOnTransientError(func() error {
 		return put(req, img, tagsToPush, opts)
 	})
 	if err != nil {

--- a/export_test.go
+++ b/export_test.go
@@ -13,6 +13,7 @@ var ExchangeACRRefreshToken = exchangeACRRefreshToken
 var AcrChallengeTenant = acrChallengeTenant
 var NewACRHTTPClient = newACRHTTPClient
 var ResolveAzureCloud = resolveAzureCloud
+var IsTransientError = isTransientError
 
 // PlainHTTPClient is a test helper client used for plain-HTTP test servers.
 var PlainHTTPClient = &http.Client{Timeout: 5 * time.Second}


### PR DESCRIPTION
In our CI I've seen errors like:

```
download failed: write rootfs: extract image: stream error: stream ID 67; INTERNAL_ERROR; received from peer
```
and others like `connection reset by peer`.

This PR expands the retry logic by also retrying on these transient errors. This should reduce the number of failed `get` steps resulting from these type of errors.