### PR TITLE
Detect layer compression by content, not media type

### DIFF
--- a/commands/rootfs.go
+++ b/commands/rootfs.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"archive/tar"
+	"bufio"
+	"bytes"
 	"compress/gzip"
 	"io"
 	"os"
@@ -195,26 +197,53 @@ func extractLayer(dest string, layer v1.Layer, bar *mpb.Bar, chown bool) error {
 
 type compressReaderClose func() error
 
+// Layer compression magic numbers.
+var (
+	zstdMagic = []byte{0x28, 0xb5, 0x2f, 0xfd}
+	gzipMagic = []byte{0x1f, 0x8b}
+)
+
+// compressionReader returns a tar.Reader over the (possibly compressed) layer.
+//
+// It detects the compression from the layer's own leading bytes rather than
+// trusting the declared media type. Builders and registries don't always label
+// zstd layers with the OCI media type (types.OCILayerZStd); BuildKit pushing
+// with Docker schema2 emits application/vnd.docker.image.rootfs.diff.tar.zstd,
+// which a media-type switch mis-routes to gzip and fails with
+// "gzip: invalid header". Sniffing the magic bytes handles gzip, zstd, and
+// uncompressed tar regardless of how the layer is labeled. mediaType is kept
+// for signature compatibility but no longer drives the decision.
 func compressionReader(layer io.ReadCloser, mediaType types.MediaType, bar *mpb.Bar) (*tar.Reader, compressReaderClose, error) {
 	var cr io.Reader
 	var crc func() error
 
-	switch mediaType {
-	case types.OCILayerZStd:
-		reader, err := zstd.NewReader(bar.ProxyReader(layer))
+	br := bufio.NewReader(bar.ProxyReader(layer))
+	magic, err := br.Peek(4)
+	if err != nil && err != io.EOF {
+		return nil, nil, err
+	}
+
+	switch {
+	case bytes.HasPrefix(magic, zstdMagic):
+		reader, err := zstd.NewReader(br)
 		if err != nil {
 			return nil, nil, err
 		}
 		cr = reader
 		crc = func() error { reader.Close(); return nil }
 
-	default:
-		reader, err := gzip.NewReader(bar.ProxyReader(layer))
+	case bytes.HasPrefix(magic, gzipMagic):
+		reader, err := gzip.NewReader(br)
 		if err != nil {
 			return nil, nil, err
 		}
 		cr = reader
 		crc = func() error { return reader.Close() }
+
+	default:
+		// Uncompressed tar (or unknown) — read the stream as-is.
+		cr = br
+		crc = func() error { return nil }
 	}
 
 	tr := tar.NewReader(cr)


### PR DESCRIPTION
## What

`extractLayer` chose the decompressor from the layer's **declared media type**: only `types.OCILayerZStd` was treated as zstd, and everything else fell through to gzip. That breaks for zstd layers labeled with a non-OCI media type — most commonly **BuildKit pushing with Docker schema2**, which emits `application/vnd.docker.image.rootfs.diff.tar.zstd`. The media-type switch routes those to `gzip.NewReader`, so `in` fails with:

```
write rootfs: extract image: gzip: invalid header
```

This is increasingly common as people adopt zstd-layer base images (e.g. hardened/minimal bases) and push them through standard `docker/build-push-action` without forcing OCI media types.

## Fix

Detect the compression from the layer's own leading **magic bytes** instead of trusting the media-type label:

- zstd -> `28 b5 2f fd`
- gzip -> `1f 8b`
- otherwise -> read as an uncompressed tar

So gzip, zstd, and uncompressed layers all unpack regardless of whether they're labeled OCI or Docker media types. `mediaType` is kept in the signature for compatibility but no longer drives the decision.

## Repro

```sh
# zstd layers under Docker schema2 media types (oci-mediatypes=false)
docker buildx build --output type=image,name=$IMG,push=true,compression=zstd,force-compression=true,oci-mediatypes=false .
```
`get` of `$IMG` fails with `gzip: invalid header` before this change; succeeds after.

## Notes

- No behavior change for existing gzip / OCI-zstd images (same decompressors, just selected by content).
- Single file (`commands/rootfs.go`). Happy to add a regression test fixture (a Docker-schema2 zstd image alongside the existing OCI-zstd one in `testdata/setup-images`) if you'd like it in this PR.
