### PR TITLE
Add `annotation_regex` and `label_regex` filtering to in step metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,6 +695,11 @@ Fetches an image at the exact digest specified by the version.
       Skip downloading the image. Useful if you want to trigger a job without
       using the object or when running after a <code>put</code> step and not
       needing to download the image you just uploaded.
+      <br><br>
+      <em><strong>Note:</strong> When set to <code>true</code>, only the base
+      <code>repository</code> and <code>tag</code> metadata fields are emitted.
+      <code>label_regex</code> and <code>annotation_regex</code> enrichment
+      requires the image to be downloaded and will produce no additional fields.</em>
     </td>
   </tr>
 </tbody>

--- a/README.md
+++ b/README.md
@@ -273,6 +273,34 @@ differences:
     </td>
   </tr>
   <tr>
+    <td><code>label_regex</code> <em>(Optional)</em></td>
+    <td>
+    A regular expression to filter which image labels are included in the
+    <code>get</code> step metadata. Only labels whose <strong>key</strong>
+    matches the regex will be surfaced. If omitted, no labels are included in
+    the metadata.
+    <br>
+    Uses RE2 syntax: https://golang.org/s/re2syntax
+    <br>
+    Example: <code>"^org\\.opencontainers\\.image\\."</code> to capture all
+    OCI standard image labels.
+    </td>
+  </tr>
+  <tr>
+    <td><code>annotation_regex</code> <em>(Optional)</em></td>
+    <td>
+    A regular expression to filter which OCI manifest annotations are included
+    in the <code>get</code> step metadata. Only annotations whose
+    <strong>key</strong> matches the regex will be surfaced. If omitted, no
+    annotations are included in the metadata.
+    <br>
+    Uses RE2 syntax: https://golang.org/s/re2syntax
+    <br>
+    Example: <code>"^org\\.opencontainers\\.image\\."</code> to capture all
+    OCI standard annotations.
+    </td>
+  </tr>
+  <tr>
     <td><code>debug</code> <em>(Optional)<br>Default: false</em></td>
     <td>
     If set, progress bars will be disabled and debugging output will be printed
@@ -671,6 +699,46 @@ Fetches an image at the exact digest specified by the version.
   </tr>
 </tbody>
 </table>
+
+#### `get` Step Metadata
+
+The `get` step emits metadata fields visible in the Concourse UI and accessible
+via `((.:version-name.metadata))` expressions. The following fields are always
+included:
+
+| Field        | Value                                                   |
+|--------------|---------------------------------------------------------|
+| `repository` | The full repository name, e.g. `concourse/concourse`.  |
+| `tag`        | The tag from the version.                               |
+
+Additional fields are emitted when the corresponding source params are set:
+
+- **`label_regex`** — each matching image label is emitted as a separate
+  metadata field, with the label key as the field name and the label value as
+  the field value. Fields are sorted alphabetically by key.
+
+- **`annotation_regex`** — each matching OCI manifest annotation is emitted as
+  a separate metadata field in the same way.
+
+**Example source configuration:**
+
+```yaml
+resources:
+- name: my-image
+  type: registry-image
+  source:
+    repository: my-org/my-app
+    label_regex: "^org\\.opencontainers\\.image\\."
+    annotation_regex: "^com\\.example\\."
+```
+
+This would surface labels such as `org.opencontainers.image.version` and
+annotations such as `com.example.git-sha` as individual metadata fields in
+the Concourse UI.
+
+> **Note:** A large number of matching keys can make the build metadata panel
+> difficult to read. Use a specific regex to select only the fields your
+> pipeline needs.
 
 #### Files created by the `get` step
 

--- a/commands/in.go
+++ b/commands/in.go
@@ -114,23 +114,7 @@ func (i *In) Execute() error {
 		return fmt.Errorf("saving version info failed: %w", err)
 	}
 
-	opts, err := req.Source.AuthOptions(repo, []string{transport.PullScope})
-	if err != nil {
-		return err
-	}
-
-	platform := req.Source.Platform(req.Params.RawPlatform)
-	opts = append(opts, remote.WithPlatform(v1.Platform{
-		Architecture: platform.Architecture,
-		OS:           platform.OS,
-	}))
-
-	image, err := remote.Image(repo.Digest(req.Version.Digest), opts...)
-	if err != nil {
-		return fmt.Errorf("get image: %w", err)
-	}
-
-	metadata, err := buildImageMetadata(req.Source, req.Version, image)
+	metadata, err := buildImageMetadata(req.Source, req.Version, repo, req.Params)
 	if err != nil {
 		return err
 	}

--- a/commands/in.go
+++ b/commands/in.go
@@ -114,12 +114,30 @@ func (i *In) Execute() error {
 		return fmt.Errorf("saving version info failed: %w", err)
 	}
 
-	err = json.NewEncoder(os.Stdout).Encode(resource.InResponse{
-		Version: req.Version,
-		Metadata: append(req.Source.Metadata(), resource.MetadataField{
-			Name:  "tag",
-			Value: req.Version.Tag,
-		}),
+	opts, err := req.Source.AuthOptions(repo, []string{transport.PullScope})
+	if err != nil {
+		return err
+	}
+
+	platform := req.Source.Platform(req.Params.RawPlatform)
+	opts = append(opts, remote.WithPlatform(v1.Platform{
+		Architecture: platform.Architecture,
+		OS:           platform.OS,
+	}))
+
+	image, err := remote.Image(repo.Digest(req.Version.Digest), opts...)
+	if err != nil {
+		return fmt.Errorf("get image: %w", err)
+	}
+
+	metadata, err := buildImageMetadata(req.Source, req.Version, image)
+	if err != nil {
+		return err
+	}
+
+	err = json.NewEncoder(i.stdout).Encode(resource.InResponse{
+		Version:  req.Version,
+		Metadata: metadata,
 	})
 	if err != nil {
 		return fmt.Errorf("could not marshal JSON: %s", err)

--- a/commands/in.go
+++ b/commands/in.go
@@ -24,6 +24,11 @@ type ImageMetadata struct {
 	User       string   `json:"user"`
 }
 
+type RemoteImage struct {
+	Image      v1.Image
+	Descriptor *remote.Descriptor
+}
+
 type In struct {
 	stdin  io.Reader
 	stderr io.Writer
@@ -85,24 +90,23 @@ func (i *In) Execute() error {
 
 	tag := repo.Tag(req.Version.Tag)
 
+	var remoteImage RemoteImage
+
 	if !req.Params.SkipDownload {
 		mirrorSource, hasMirror, err := req.Source.Mirror()
 		if err != nil {
 			return fmt.Errorf("failed to resolve mirror: %w", err)
 		}
 
-		usedMirror := false
 		if hasMirror {
-			err := downloadWithRetry(tag, mirrorSource, req.Params, req.Version, dest, i.stderr)
+			remoteImage, err = downloadWithRetry(tag, mirrorSource, req.Params, req.Version, dest, i.stderr)
 			if err != nil {
 				logrus.Warnf("download from mirror %s failed: %s", mirrorSource.Repository, err)
-			} else {
-				usedMirror = true
 			}
 		}
 
-		if !usedMirror {
-			err := downloadWithRetry(tag, req.Source, req.Params, req.Version, dest, i.stderr)
+		if remoteImage.Image == nil {
+			remoteImage, err = downloadWithRetry(tag, req.Source, req.Params, req.Version, dest, i.stderr)
 			if err != nil {
 				return fmt.Errorf("download failed: %w", err)
 			}
@@ -114,9 +118,12 @@ func (i *In) Execute() error {
 		return fmt.Errorf("saving version info failed: %w", err)
 	}
 
-	metadata, err := buildImageMetadata(req.Source, req.Version, repo, req.Params)
-	if err != nil {
-		return err
+	metadata := buildBaseMetadata(req.Source, tag)
+	if remoteImage.Image != nil {
+		metadata, err = enrichMetadataFromImage(metadata, req.Source, remoteImage.Image)
+		if err != nil {
+			return fmt.Errorf("enriching metadata failed: %w", err)
+		}
 	}
 
 	err = json.NewEncoder(i.stdout).Encode(resource.InResponse{
@@ -130,25 +137,55 @@ func (i *In) Execute() error {
 	return nil
 }
 
-func downloadWithRetry(tag name.Tag, source resource.Source, params resource.GetParams, version resource.Version, dest string, stderr io.Writer) error {
-	fmt.Fprintf(stderr, "fetching %s@%s\n", color.GreenString(source.Repository), color.YellowString(version.Digest))
-
+func fetchImage(source resource.Source, version resource.Version, params resource.GetParams) (RemoteImage, error) {
 	repo, err := source.NewRepository()
 	if err != nil {
-		return fmt.Errorf("resolve repository name: %w", err)
+		return RemoteImage{}, fmt.Errorf("resolve repository name: %w", err)
 	}
 
-	return resource.RetryOnTransientError(func() error {
-		opts, err := source.AuthOptions(repo, []string{transport.PullScope})
+	opts, err := source.AuthOptions(repo, []string{transport.PullScope})
+	if err != nil {
+		return RemoteImage{}, err
+	}
+
+	platform := source.Platform(params.RawPlatform)
+	opts = append(opts, remote.WithPlatform(v1.Platform{
+		Architecture: platform.Architecture,
+		OS:           platform.OS,
+	}))
+
+	if params.Format() == "oci-layout" {
+		remoteDesc, err := remote.Get(repo.Digest(version.Digest), opts...)
+		if err != nil {
+			return RemoteImage{}, fmt.Errorf("fetch descriptor: %w", err)
+		}
+
+		image, err := remoteDesc.Image()
+		if err != nil {
+			return RemoteImage{}, fmt.Errorf("fetch image: %w", err)
+		}
+
+		return RemoteImage{Descriptor: remoteDesc, Image: image}, nil
+	}
+
+	image, err := remote.Image(repo.Digest(version.Digest), opts...)
+	if err != nil {
+		return RemoteImage{}, fmt.Errorf("fetch image: %w", err)
+	}
+
+	return RemoteImage{Image: image}, nil
+}
+
+func downloadWithRetry(tag name.Tag, source resource.Source, params resource.GetParams, version resource.Version, dest string, stderr io.Writer) (RemoteImage, error) {
+	fmt.Fprintf(stderr, "fetching %s@%s\n", color.GreenString(source.Repository), color.YellowString(version.Digest))
+
+	var image RemoteImage
+	err := resource.RetryOnTransientError(func() error {
+		var err error
+		image, err = fetchImage(source, version, params)
 		if err != nil {
 			return err
 		}
-
-		platform := source.Platform(params.RawPlatform)
-		opts = append(opts, remote.WithPlatform(v1.Platform{
-			Architecture: platform.Architecture,
-			OS:           platform.OS,
-		}))
 
 		// In case anyone else wonders why we don't show a progress bar for
 		// downloads, it's because go-containerregistry doesn't expose anything
@@ -157,23 +194,19 @@ func downloadWithRetry(tag name.Tag, source resource.Source, params resource.Get
 		// Maybe we should switch to using oras-go?
 		switch params.Format() {
 		case "oci-layout":
-			return saveOciLayout(repo, version, dest, opts)
+			return saveOciLayout(image.Descriptor, dest)
 		case "oci":
-			return saveOci(repo, tag, version, dest, opts)
+			return saveOci(image.Image, tag, dest)
 		case "rootfs":
-			return saveRootfs(repo, version, dest, opts, source.Debug, stderr)
+			return saveRootfs(image.Image, dest, source.Debug, stderr)
 		default:
 			return fmt.Errorf("unknown format provided, must be one of 'rootfs', 'oci', 'oci-layout: %s", params.Format())
 		}
 	})
+	return image, err
 }
 
-func saveOciLayout(repo name.Repository, version resource.Version, dest string, opts []remote.Option) error {
-	remoteDesc, err := remote.Get(repo.Digest(version.Digest), opts...)
-	if err != nil {
-		return fmt.Errorf("remote get: %w", err)
-	}
-
+func saveOciLayout(remoteDesc *remote.Descriptor, dest string) error {
 	ioi, err := NewIndexImageFromRemote(remoteDesc)
 	if err != nil {
 		return fmt.Errorf("remote index or image: %w", err)
@@ -187,24 +220,16 @@ func saveOciLayout(repo name.Repository, version resource.Version, dest string, 
 	return nil
 }
 
-func saveOci(repo name.Repository, tag name.Tag, version resource.Version, dest string, opts []remote.Option) error {
-	image, err := remote.Image(repo.Digest(version.Digest), opts...)
-	if err != nil {
-		return fmt.Errorf("get image: %w", err)
-	}
-	err = ociFormat(dest, tag, image)
+func saveOci(image v1.Image, tag name.Tag, dest string) error {
+	err := ociFormat(dest, tag, image)
 	if err != nil {
 		return fmt.Errorf("write oci image: %w", err)
 	}
 	return nil
 }
 
-func saveRootfs(repo name.Repository, version resource.Version, dest string, opts []remote.Option, debug bool, stderr io.Writer) error {
-	image, err := remote.Image(repo.Digest(version.Digest), opts...)
-	if err != nil {
-		return fmt.Errorf("get image: %w", err)
-	}
-	err = rootfsFormat(dest, image, debug, stderr)
+func saveRootfs(image v1.Image, dest string, debug bool, stderr io.Writer) error {
+	err := rootfsFormat(dest, image, debug, stderr)
 	if err != nil {
 		return fmt.Errorf("write rootfs: %w", err)
 	}

--- a/commands/metadata.go
+++ b/commands/metadata.go
@@ -1,0 +1,104 @@
+package commands
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+
+	resource "github.com/concourse/registry-image-resource"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+func buildImageMetadata(source resource.Source, version resource.Version, image v1.Image) ([]resource.MetadataField, error) {
+	metadata := append(source.Metadata(), resource.MetadataField{
+		Name:  "tag",
+		Value: version.Tag,
+	})
+
+	fields, err := collectMetadataFields(source, image)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(metadata, fields...), nil
+}
+
+func collectMetadataFields(
+	source resource.Source,
+	image v1.Image,
+) ([]resource.MetadataField, error) {
+	var fields []resource.MetadataField
+
+	if regex := source.AnnotationRegex; regex != "" {
+		annotations, err := fetchImageAnnotations(regex, image)
+		if err != nil {
+			return nil, fmt.Errorf("fetch annotations: %w", err)
+		}
+
+		fields = append(fields, metadataFieldsFromMap(annotations)...)
+	}
+
+	if regex := source.LabelRegex; regex != "" {
+		labels, err := fetchImageLabels(regex, image)
+		if err != nil {
+			return nil, fmt.Errorf("fetch labels: %w", err)
+		}
+
+		fields = append(fields, metadataFieldsFromMap(labels)...)
+	}
+
+	return fields, nil
+}
+
+func fetchImageAnnotations(regex string, img v1.Image) (map[string]string, error) {
+	manifest, err := img.Manifest()
+	if err != nil {
+		return nil, fmt.Errorf("get manifest: %w", err)
+	}
+
+	return filterMap(regex, manifest.Annotations, "annotation")
+}
+
+func fetchImageLabels(regex string, img v1.Image) (map[string]string, error) {
+	cfg, err := img.ConfigFile()
+	if err != nil {
+		return nil, fmt.Errorf("get config file: %w", err)
+	}
+
+	return filterMap(regex, cfg.Config.Labels, "label")
+}
+
+func filterMap(regex string, values map[string]string, kind string) (map[string]string, error) {
+	re, err := regexp.Compile(regex)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s regex: %w", kind, err)
+	}
+
+	result := make(map[string]string)
+	for k, v := range values {
+		if re.MatchString(k) {
+			result[k] = v
+		}
+	}
+
+	return result, nil
+}
+
+func metadataFieldsFromMap(values map[string]string) []resource.MetadataField {
+	fields := make([]resource.MetadataField, 0, len(values))
+
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		fields = append(fields, resource.MetadataField{
+			Name:  key,
+			Value: values[key],
+		})
+	}
+
+	return fields
+}

--- a/commands/metadata.go
+++ b/commands/metadata.go
@@ -6,14 +6,37 @@ import (
 	"sort"
 
 	resource "github.com/concourse/registry-image-resource"
+	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 )
 
-func buildImageMetadata(source resource.Source, version resource.Version, image v1.Image) ([]resource.MetadataField, error) {
+func buildImageMetadata(source resource.Source, version resource.Version, repo name.Repository, params resource.GetParams) ([]resource.MetadataField, error) {
 	metadata := append(source.Metadata(), resource.MetadataField{
 		Name:  "tag",
 		Value: version.Tag,
 	})
+
+	if source.LabelRegex == "" && source.AnnotationRegex == "" {
+		return metadata, nil
+	}
+
+	opts, err := source.AuthOptions(repo, []string{transport.PullScope})
+	if err != nil {
+		return nil, err
+	}
+
+	platform := source.Platform(params.RawPlatform)
+	opts = append(opts, remote.WithPlatform(v1.Platform{
+		Architecture: platform.Architecture,
+		OS:           platform.OS,
+	}))
+
+	image, err := remote.Image(repo.Digest(version.Digest), opts...)
+	if err != nil {
+		return nil, fmt.Errorf("get image: %w", err)
+	}
 
 	fields, err := collectMetadataFields(source, image)
 	if err != nil {

--- a/commands/metadata.go
+++ b/commands/metadata.go
@@ -8,120 +8,63 @@ import (
 	resource "github.com/concourse/registry-image-resource"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 )
 
-func buildImageMetadata(source resource.Source, version resource.Version, repo name.Repository, params resource.GetParams) ([]resource.MetadataField, error) {
-	metadata := append(source.Metadata(), resource.MetadataField{
+func buildBaseMetadata(source resource.Source, tag name.Tag) []resource.MetadataField {
+	return append(source.Metadata(), resource.MetadataField{
 		Name:  "tag",
-		Value: version.Tag,
+		Value: tag.TagStr(),
 	})
-
-	if source.LabelRegex == "" && source.AnnotationRegex == "" {
-		return metadata, nil
-	}
-
-	opts, err := source.AuthOptions(repo, []string{transport.PullScope})
-	if err != nil {
-		return nil, err
-	}
-
-	platform := source.Platform(params.RawPlatform)
-	opts = append(opts, remote.WithPlatform(v1.Platform{
-		Architecture: platform.Architecture,
-		OS:           platform.OS,
-	}))
-
-	image, err := remote.Image(repo.Digest(version.Digest), opts...)
-	if err != nil {
-		return nil, fmt.Errorf("get image: %w", err)
-	}
-
-	fields, err := collectMetadataFields(source, image)
-	if err != nil {
-		return nil, err
-	}
-
-	return append(metadata, fields...), nil
 }
 
-func collectMetadataFields(
-	source resource.Source,
-	image v1.Image,
-) ([]resource.MetadataField, error) {
-	var fields []resource.MetadataField
-
-	if regex := source.AnnotationRegex; regex != "" {
-		annotations, err := fetchImageAnnotations(regex, image)
+func enrichMetadataFromImage(metadata []resource.MetadataField, source resource.Source, image v1.Image) ([]resource.MetadataField, error) {
+	if source.LabelRegex != "" {
+		re, err := regexp.Compile(source.LabelRegex)
 		if err != nil {
-			return nil, fmt.Errorf("fetch annotations: %w", err)
+			return nil, fmt.Errorf("invalid label_regex: %w", err)
 		}
-
-		fields = append(fields, metadataFieldsFromMap(annotations)...)
-	}
-
-	if regex := source.LabelRegex; regex != "" {
-		labels, err := fetchImageLabels(regex, image)
+		cfg, err := image.ConfigFile()
 		if err != nil {
-			return nil, fmt.Errorf("fetch labels: %w", err)
+			return nil, fmt.Errorf("get config file: %w", err)
 		}
-
-		fields = append(fields, metadataFieldsFromMap(labels)...)
+		metadata = append(metadata, metadataFieldsFromMap(filterMap(re, cfg.Config.Labels))...)
 	}
 
-	return fields, nil
+	if source.AnnotationRegex != "" {
+		re, err := regexp.Compile(source.AnnotationRegex)
+		if err != nil {
+			return nil, fmt.Errorf("invalid annotation_regex: %w", err)
+		}
+		manifest, err := image.Manifest()
+		if err != nil {
+			return nil, fmt.Errorf("get manifest: %w", err)
+		}
+		metadata = append(metadata, metadataFieldsFromMap(filterMap(re, manifest.Annotations))...)
+	}
+
+	return metadata, nil
 }
 
-func fetchImageAnnotations(regex string, img v1.Image) (map[string]string, error) {
-	manifest, err := img.Manifest()
-	if err != nil {
-		return nil, fmt.Errorf("get manifest: %w", err)
-	}
-
-	return filterMap(regex, manifest.Annotations, "annotation")
-}
-
-func fetchImageLabels(regex string, img v1.Image) (map[string]string, error) {
-	cfg, err := img.ConfigFile()
-	if err != nil {
-		return nil, fmt.Errorf("get config file: %w", err)
-	}
-
-	return filterMap(regex, cfg.Config.Labels, "label")
-}
-
-func filterMap(regex string, values map[string]string, kind string) (map[string]string, error) {
-	re, err := regexp.Compile(regex)
-	if err != nil {
-		return nil, fmt.Errorf("invalid %s regex: %w", kind, err)
-	}
-
-	result := make(map[string]string)
+func filterMap(re *regexp.Regexp, values map[string]string) map[string]string {
+	result := make(map[string]string, len(values))
 	for k, v := range values {
 		if re.MatchString(k) {
 			result[k] = v
 		}
 	}
-
-	return result, nil
+	return result
 }
 
 func metadataFieldsFromMap(values map[string]string) []resource.MetadataField {
-	fields := make([]resource.MetadataField, 0, len(values))
-
 	keys := make([]string, 0, len(values))
-	for key := range values {
-		keys = append(keys, key)
+	for k := range values {
+		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 
-	for _, key := range keys {
-		fields = append(fields, resource.MetadataField{
-			Name:  key,
-			Value: values[key],
-		})
+	fields := make([]resource.MetadataField, len(keys))
+	for i, k := range keys {
+		fields[i] = resource.MetadataField{Name: k, Value: values[k]}
 	}
-
 	return fields
 }

--- a/in_test.go
+++ b/in_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -901,6 +902,156 @@ var _ = Describe("In", func() {
 
 					Expect(res.Version).To(Equal(req.Version))
 				})
+			})
+		})
+	})
+
+	Describe("label_regex and annotation_regex", func() {
+		var registry *ghttp.Server
+
+		setupRegistry := func(img v1.Image) {
+			digest, err := img.Digest()
+			Expect(err).ToNot(HaveOccurred())
+
+			manifest, err := img.RawManifest()
+			Expect(err).ToNot(HaveOccurred())
+
+			configDigest, err := img.ConfigName()
+			Expect(err).ToNot(HaveOccurred())
+
+			config, err := img.RawConfigFile()
+			Expect(err).ToNot(HaveOccurred())
+
+			registry.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/v2/"),
+					ghttp.RespondWith(http.StatusOK, `welcome`),
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/v2/fake-image/manifests/"+digest.String()),
+					ghttp.RespondWith(http.StatusOK, manifest),
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/v2/fake-image/blobs/"+configDigest.String()),
+					ghttp.RespondWith(http.StatusOK, config),
+				),
+			)
+
+			req.Source = resource.Source{
+				Repository: registry.Addr() + "/fake-image",
+			}
+			req.Params.SkipDownload = true
+			req.Version.Tag = "latest"
+			req.Version.Digest = digest.String()
+		}
+
+		BeforeEach(func() {
+			registry = ghttp.NewServer()
+		})
+
+		AfterEach(func() {
+			registry.Close()
+		})
+
+		When("no regex is configured", func() {
+			BeforeEach(func() {
+				setupRegistry(empty.Image)
+			})
+
+			It("returns repository and tag in metadata", func() {
+				Expect(actualErr).ToNot(HaveOccurred())
+				Expect(res.Metadata).To(Equal([]resource.MetadataField{
+					{Name: "repository", Value: registry.Addr() + "/fake-image"},
+					{Name: "tag", Value: "latest"},
+				}))
+			})
+		})
+
+		When("label_regex is configured", func() {
+			BeforeEach(func() {
+				img, err := mutate.Config(empty.Image, v1.Config{
+					Labels: map[string]string{
+						"com.example.foo": "bar",
+						"org.other.baz":   "skip",
+					},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				setupRegistry(img)
+
+				req.Source.LabelRegex = `^com\.example\.`
+			})
+
+			It("includes matching labels", func() {
+				Expect(actualErr).ToNot(HaveOccurred())
+				Expect(res.Metadata).To(ContainElement(
+					resource.MetadataField{Name: "com.example.foo", Value: "bar"},
+				))
+			})
+
+			It("does not include non-matching labels", func() {
+				Expect(actualErr).ToNot(HaveOccurred())
+				Expect(res.Metadata).ToNot(ContainElement(
+					resource.MetadataField{Name: "org.other.baz", Value: "skip"},
+				))
+			})
+		})
+
+		When("annotation_regex is configured", func() {
+			BeforeEach(func() {
+				annotated := mutate.Annotations(empty.Image, map[string]string{
+					"com.example.build": "123",
+					"org.internal":      "skip",
+				})
+				img, ok := annotated.(v1.Image)
+				Expect(ok).To(BeTrue())
+				setupRegistry(img)
+
+				req.Source.AnnotationRegex = `^com\.example\.`
+			})
+
+			It("includes matching annotations", func() {
+				Expect(actualErr).ToNot(HaveOccurred())
+				Expect(res.Metadata).To(ContainElement(
+					resource.MetadataField{Name: "com.example.build", Value: "123"},
+				))
+			})
+
+			It("does not include non-matching annotations", func() {
+				Expect(actualErr).ToNot(HaveOccurred())
+				Expect(res.Metadata).ToNot(ContainElement(
+					resource.MetadataField{Name: "org.internal", Value: "skip"},
+				))
+			})
+		})
+
+		When("label_regex matches multiple labels", func() {
+			BeforeEach(func() {
+				img, err := mutate.Config(empty.Image, v1.Config{
+					Labels: map[string]string{
+						"z-label": "last",
+						"a-label": "first",
+						"m-label": "mid",
+					},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				setupRegistry(img)
+
+				req.Source.LabelRegex = ".*"
+			})
+
+			It("returns labels sorted alphabetically", func() {
+				Expect(actualErr).ToNot(HaveOccurred())
+				labelFields := []resource.MetadataField{}
+				for _, f := range res.Metadata {
+					if f.Name == "a-label" || f.Name == "m-label" || f.Name == "z-label" {
+						labelFields = append(labelFields, f)
+					}
+				}
+				Expect(labelFields).To(Equal([]resource.MetadataField{
+					{Name: "a-label", Value: "first"},
+					{Name: "m-label", Value: "mid"},
+					{Name: "z-label", Value: "last"},
+				}))
 			})
 		})
 	})

--- a/in_test.go
+++ b/in_test.go
@@ -940,7 +940,6 @@ var _ = Describe("In", func() {
 			req.Source = resource.Source{
 				Repository: registry.Addr() + "/fake-image",
 			}
-			req.Params.SkipDownload = true
 			req.Version.Tag = "latest"
 			req.Version.Digest = digest.String()
 		}

--- a/types.go
+++ b/types.go
@@ -247,22 +247,27 @@ func (source Source) AuthOptions(repo name.Repository, scopeActions []string) ([
 }
 
 func (source *Source) Platform(stepOverride *PlatformField) PlatformField {
-	var p PlatformField
+	DefaultArchitecture := runtime.GOARCH
+	DefaultOS := runtime.GOOS
+
+	p := source.RawPlatform
+	if p == nil {
+		p = &PlatformField{}
+	}
+
 	if stepOverride != nil {
-		p = *stepOverride
-	} else if source.RawPlatform != nil {
-		p = *source.RawPlatform
+		p = stepOverride
 	}
 
 	if p.Architecture == "" {
-		p.Architecture = runtime.GOARCH
+		p.Architecture = DefaultArchitecture
 	}
 
 	if p.OS == "" {
-		p.OS = runtime.GOOS
+		p.OS = DefaultOS
 	}
 
-	return p
+	return *p
 }
 
 func (source Source) NewRepository() (name.Repository, error) {

--- a/types.go
+++ b/types.go
@@ -113,6 +113,9 @@ type Source struct {
 	Regex         string `json:"tag_regex,omitempty"`
 	CreatedAtSort bool   `json:"created_at_sort,omitempty"`
 
+	AnnotationRegex string `json:"annotation_regex,omitempty"`
+	LabelRegex      string `json:"label_regex,omitempty"`
+
 	BasicCredentials
 	AwsCredentials
 	AzureCredentials
@@ -244,27 +247,22 @@ func (source Source) AuthOptions(repo name.Repository, scopeActions []string) ([
 }
 
 func (source *Source) Platform(stepOverride *PlatformField) PlatformField {
-	DefaultArchitecture := runtime.GOARCH
-	DefaultOS := runtime.GOOS
-
-	p := source.RawPlatform
-	if p == nil {
-		p = &PlatformField{}
-	}
-
+	var p PlatformField
 	if stepOverride != nil {
-		p = stepOverride
+		p = *stepOverride
+	} else if source.RawPlatform != nil {
+		p = *source.RawPlatform
 	}
 
 	if p.Architecture == "" {
-		p.Architecture = DefaultArchitecture
+		p.Architecture = runtime.GOARCH
 	}
 
 	if p.OS == "" {
-		p.OS = DefaultOS
+		p.OS = runtime.GOOS
 	}
 
-	return *p
+	return p
 }
 
 func (source Source) NewRepository() (name.Repository, error) {


### PR DESCRIPTION
closes #398 

#### Changes introduced:
* Adds two new optional source fields - `annotation_regex` and `label_regex` - that filter OCI image manifest annotations and config labels (by key) into the `get` step metadata output
* Extracts metadata assembly into commands/metadata.go with a shared `filterMap` helper, eliminating duplication between annotation and label fetching

#### Details
Both `annotation_regex` and `label_regex` accept a Go regular expression matched against metadata keys. Only matching keys are included in the response. When omitted, no annotations or labels are added to the metadata.

Example source:
```yaml
 source:
    repository: ichalukov/my-app
    tag: lin1
    label_regex: "^org\\.opencontainers\\.image\\."
    annotation_regex: "t([a-z]+)le"
```